### PR TITLE
plate-ext-id input: .val('') to reset upon refreshing + align glyphicons

### DIFF
--- a/labman/gui/templates/compression.html
+++ b/labman/gui/templates/compression.html
@@ -92,6 +92,10 @@
                       }]
       }
     );
+
+	// Empty input textbox on loading
+	$('#plate-ext-id').val('');
+
     // Add the function to the buttons that add the plate to the compression process
     $('#searchPlateTable tbody').on('click', 'button', function() {
       addPlate(table.row( $(this).parents('tr') ).data()[0]);
@@ -124,10 +128,12 @@
 </div>
 
 <!-- Compressed plate name -->
-<div id='plate-ext-id-div' class='form-group has-error has-feedback'>
+<div id='plate-ext-id-div' class='form-group'>
   <label class='control-label'><h4>Compressed plate name:</h4></label>
-  <input type='text' id='plate-ext-id' class='form-control' />
-  <span class='glyphicon glyphicon-remove form-control-feedback'></span>
+    <div class='form-group has-error has-feedback'>
+      <input type='text' id='plate-ext-id' class='form-control'>
+	  <span class='glyphicon glyphicon-remove form-control-feedback'></span>
+	</div>
 </div>
 
 <div>


### PR DESCRIPTION
that solves issue #73 (gDNA compression should allow to compress 1 plate)

- refreshing page was keeping any text written in "Compressed plate name" textbox.
Fix => reset jQuery value to empty string in document ready statement.
- glyphicon misaligned in "Compressed plate name" textbox (in a third rows between label and input)
Fix => add a \<div\> layer.