### PR TITLE
Interface to find sample plates on which specified sample(s) are present

### DIFF
--- a/labman/gui/handlers/plate.py
+++ b/labman/gui/handlers/plate.py
@@ -37,6 +37,25 @@ def _get_plate(plate_id):
     return plate
 
 
+class PlateSearchHandler(BaseHandler):
+    @authenticated
+    def get(self):
+        self.render('plate_search.html')
+
+    @authenticated
+    def post(self):
+        plate_comment_keywords = self.get_argument("plate_comment_keywords")
+        well_comment_keywords = self.get_argument("well_comment_keywords")
+        operation = self.get_argument("operation")
+        sample_names = json_decode(self.get_argument('sample_names'))
+
+        res = {"data": [[p.id, p.external_id]
+               for p in Plate.search(sample=sample_names, plate_notes=plate_comment_keywords,
+                                     well_notes=well_comment_keywords, query_type=operation)]}
+
+        self.write(res)
+
+
 class PlateListingHandler(BaseHandler):
     @authenticated
     def get(self):

--- a/labman/gui/templates/plate_search.html
+++ b/labman/gui/templates/plate_search.html
@@ -1,0 +1,295 @@
+{% extends sitebase.html %}
+{% block head %}
+
+<link rel="stylesheet" href="/static/vendor/css/slick-default-theme.css" type="text/css"/>
+<link rel="stylesheet" href="/static/vendor/css/slick.grid.css" type="text/css"/>
+<link rel="stylesheet" href="/static/vendor/css/jquery-ui.min.css" type="text/css"/>
+
+<script src="/static/vendor/js/jquery.event.drag-2.3.0.js" type="text/javascript"></script>
+<!-- not sure I need these slick libraries, but I am using plateViewer, which may use them, so keeping them -->
+<script src="/static/vendor/js/slick.core.js" type="text/javascript"></script>
+<script src="/static/vendor/js/slick.grid.js" type="text/javascript"></script>
+<script src="/static/vendor/js/slick.editors.js" type="text/javascript"></script>
+<script src="/static/vendor/js/jquery-ui.min.js" type="text/javascript"></script>
+
+<script src="/static/js/plate.js"></script>
+<script src="/static/js/plateViewer.js"></script>
+<script type='text/javascript'>
+    var nextSampleIndex = 0;
+
+    //Modeled on removePlate and addPlate from extraction.html
+    function removeSample(sampleId) {
+        // Remove the plate from the list
+        $('#sample-' + sampleId).remove();
+        // Note: since I haven't added code to prevent users from adding the same sample twice,
+        // there is no code here to re-enable samples for selection after they are removed.
+
+        //enable/disable the search button
+        searchTermsCheck();
+    }
+
+    function addSample() {
+        var sampleIndex = nextSampleIndex;
+        nextSampleIndex++;
+        var $divElem = $("<div class='form-group'>");
+        $divElem.addClass('list-group-item');
+        var new_id = 'sample-' + sampleIndex;
+        $divElem.attr('id', new_id);
+        $divElem.attr('sample-index', sampleIndex);
+        var $buttonElem = $("<button class='btn btn-danger btn-circle pull-right' onclick='removeSample(" + sampleIndex + ");'>");
+        $buttonElem.append("<span class='glyphicon glyphicon-remove'></span>");
+        $divElem.append($buttonElem);
+
+        var idPrefix = "sample-input-";
+        var input_id = idPrefix + sampleIndex;
+        var $input = $("<input type='text' class='form-control editor-text' />").attr('id', input_id).appendTo($divElem);
+        //$("<span class='glyphicon glyphicon-remove form-control-feedback'></span>").appendTo($divElem);
+
+        $input.autocomplete({
+            source: autocomplete_search_samples,
+            // see https://stackoverflow.com/a/4719848
+            response: function(event, ui) {
+                var id_selector = "#" + new_id;
+                // ui.content is the array that's about to be sent to the response callback.
+                if (ui.content.length === 0) {
+                    $(id_selector).addClass("has-error");
+                } else {
+                    $(id_selector).removeClass("has-error");
+                }
+
+                searchTermsCheck();
+            }
+        });
+
+        // Add the element to the plate list
+        $('#sample-list').append($divElem);
+
+        // No code here to disable adding an already-added sample to the list, though maybe there should be
+
+        //enable/disable the search button
+        searchTermsCheck();
+    }
+
+    //comes straight from plate_list.html
+    var dtSelectedCounter = 0;
+
+    //comes straight from plate_list.html
+    function buttonClicked(address) {
+        var plateIds = [];
+        for (var inTag of $('.dt-selected').find('input')) {
+            plateIds.push($(inTag).attr('data-lb-plate-id'));
+        }
+        var urlArgs = "?plate_id=" + plateIds[0];
+        for (var pId of plateIds.slice(1)) {
+            urlArgs = urlArgs + "&plate_id=" + pId;
+        }
+        window.location.href = address + urlArgs;
+    }
+
+    function searchTermsCheck() {
+        var samples = $('#sample-list').children();
+        var invalid_samples = $('#sample-list').find(".has-error");
+        var empty = (samples.length === 0) && $('#plate-comments-keywords').val().trim() === '' && $('#well-comments-keywords').val().trim() === '';
+        var disabled = empty || (invalid_samples.length > 0);
+        $('#search-btn').prop('disabled', disabled);
+    }
+
+    function searchForPlates(){
+        // Get the samples to search for
+        var sampleNames = [];
+        var sampleIndex;
+        for (var item of $('#sample-list').children()) {
+            sampleIndex = item.getAttribute('sample-index');
+            sampleNames.push($('#sample-input' + sampleIndex).val());
+        }
+
+        // Get the keywords to search for
+        var plate_comment_keywords = $('#plate-comments-keywords').val();
+        var well_comment_keywords = $('#well-comments-keywords').val();
+
+        // Get the operation
+        var operation = $('#operation-type-select').val();
+
+        var postData = {'sample_names': JSON.stringify(sampleNames),
+                        'plate_comment_keywords': plate_comment_keywords,
+                        'well_comment_keywords': well_comment_keywords,
+                        'operation': operation
+                        };
+
+        dtSelectedCounter = 0;
+        $('#btn-div').empty();
+
+        $.post('/plate_search', postData, function(data) {
+            // Most of this content is lifted from plate_list.html, except that the only option is to view plates
+            var datatable = $('#plateListTable').DataTable(
+                {'columnDefs': [{'targets': 0, 'orderable': false, 'width': '30px'}],
+                'order': [[1, "desc"]],
+                'language': {'zeroRecords': 'No plates found'}});
+
+            var newData = [];
+            for (var row of data.data) {
+              // Add the checkbox
+              var chBox = '<input type="checkbox" class="table-checkbox" data-lb-plate-id="' + row[0] + '"></input>';
+              newData.push([chBox, row[0], row[1]]);
+            }
+
+            datatable.clear();
+            datatable.rows.add(newData);
+            datatable.draw();
+            $('#plateListTable').removeClass("hidden");
+
+
+            $('.table-checkbox').on('change', function() {
+                if (this.checked) {
+                    $(this).parent('td').parent('tr').addClass('dt-selected');
+                    dtSelectedCounter += 1;
+                    if (dtSelectedCounter === 1) {
+                        // We need to enable the buttons; assume for now the only type of plate that can
+                        // be returned is sample plate, and the only thing to do with it is view it
+                        $('<button>').addClass('btn btn-info').append('View plate').appendTo('#btn-div').on('click', function () {
+                            buttonClicked('/plate');
+                        });
+
+                        $('#btn-div').append(' ');
+                    }
+                } else {
+                    $(this).parent('td').parent('tr').removeClass('dt-selected');
+                    dtSelectedCounter -= 1;
+                    if (dtSelectedCounter === 0) {
+                        // If the counter goes to 0, we need to remove all the buttons
+                        $('#btn-div').empty();
+                    }
+                }
+            });
+        })
+        .fail(function (jqXHR, textStatus, errorThrown) {
+            bootstrapAlert(jqXHR.responseText, 'danger');
+        });
+    }
+
+    $(document).ready(function(){
+        // This is lifted straight from plate.html with the exception of changing the var name from table to search_study_table
+        // Set the study search table
+        var search_study_table = $('#searchStudyTable').DataTable(
+            {'ajax': '/study_list',
+            'columnDefs': [{'targets': -1,
+                           'data': null,
+                           'render': function(data, type, row, meta) {
+                              var studyId = data[0];
+                              return "<button id='addBtnStudy" + studyId + "' class='btn btn-success btn-circle-small'><span class='glyphicon glyphicon-plus'></span></button>";
+                            }}]
+            });
+        // Add the function to the buttons that add the study to the plate
+        $('#searchStudyTable tbody').on('click', 'button', function() {
+            add_study(search_study_table.row( $(this).parents('tr') ).data()[0]);
+        });
+
+        // this comes straight from plate_list.html; don't really understand why it is needed but I'll assume it is
+        //var table = $('#plateListTable').DataTable(
+        //    {'columnDefs': [{'targets': 0, 'orderable': false, 'width': '30px'}],
+        //    'order': [[1, "desc"]],
+        //    'language': {'zeroRecords': 'No plates found - choose a plate type'}});
+
+        $('#plate-comments-keywords').on('change', searchTermsCheck);
+        $('#well-comments-keywords').on('change', searchTermsCheck);
+    });
+</script>
+{% end %}
+{%block content %}
+
+<label><h3>Plate search</h3></label>
+
+<p>
+Search for plates by the sample(s) contained, and/or by key words included in plate or well comments.
+</p>
+
+<!-- Note that this is a straight copy-paste from plate.html; refactoring is probably in order one of these days -->
+<!-- Studies div -->
+<div>
+  <label><h4>Studies to search</h4></label>
+  <button class='btn btn-success' data-toggle='modal' data-target='#addStudyModal'><span class='glyphicon glyphicon-plus'></span> Add study</button>
+  <div id='study-list'>
+  </div>
+</div>
+
+<!-- modeled on Plates div from extraction.html -->
+<!-- Samples div -->
+<div>
+  <label><h4>Samples to search for</h4></label>
+  <button class='btn btn-success' onclick='addSample();'><span class='glyphicon glyphicon-plus'></span> Add sample</button>
+  <div id='sample-list'>
+  </div>
+</div>
+
+<!-- Plate comments keywords -->
+<div class='form-group'>
+  <label class='control-label'><h4>Keywords in plate comments:</h4></label>
+  <input type='text' id='plate-comments-keywords' class='form-control' />
+</div>
+
+<!-- Well comments keywords -->
+<div class='form-group'>
+  <label class='control-label'><h4>Keywords in well comments:</h4></label>
+  <input type='text' id='well-comments-keywords' class='form-control' />
+</div>
+
+<!-- Operation select -->
+<div class='form-group'>
+  <label class='control-label'><h4>Combination type:</h4></label>
+  <p>
+    Intersection will retrieve all the plates in which the samples AND the comments are found, while Union will retrieve the plates in which the samples OR the comments are found.
+  </p>
+  <select id='operation-type-select' class='form-control'>
+    <option selected value='INTERSECT'>Intersection</option>
+    <option value='UNION'>Union</option>
+  </select>
+
+</div>
+
+<!-- Note that this is a straight copy-paste from plate.html; refactoring is probably in order one of these days -->
+<!-- Modal to add a study -->
+<div class='modal fade' tabindex='-1' role='dialog' id='addStudyModal'>
+  <div class='modal-dialog modal-lg'>
+    <div class='modal-content'>
+      <div class='modal-header'>
+        <button type='button' class='close' data-dismiss='modal' aria-hidden='true'>&times;</button>
+        <h3>Add study to plate</h3>
+      </div>
+      <div class='modal-body'>
+        <table id="searchStudyTable" class="display" cellspacing="0" width="100%">
+          <thead>
+            <tr>
+              <th>Study id</th>
+              <th>Study title</th>
+              <th>Study alias</th>
+              <th>Study owner</th>
+              <th>Num samples</th>
+              <th>Add</th>
+            </tr>
+          </thead>
+        </table>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div>
+  <button id='search-btn' onclick="searchForPlates();" class='btn btn-success' disabled><span class='glyphicon glyphicon-share'></span> Search</button>
+</div>
+
+<br />
+
+<!-- Note that this is a straight copy-paste from plate_list.html; refactoring is probably in order one of these days -->
+<table id="plateListTable" class="hidden" cellspacing="0" width="100%">
+  <thead>
+    <tr>
+      <th></th>
+      <th>Plate id</th>
+      <th>Plate name</th>
+    </tr>
+  </thead>
+</table>
+
+<div id='btn-div'></div>
+
+{% end %}

--- a/labman/gui/templates/sitebase.html
+++ b/labman/gui/templates/sitebase.html
@@ -51,6 +51,7 @@
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Plates <span class="caret"></span></a>
                 <ul class="dropdown-menu">
                   <li><a href="/plates">List</a></li>
+                  <li><a href="/plate_search">Search</a></li>
                   <li><a href="/plate">Plate samples</a></li>
                   <li><a href="/process/gdna_extraction">Extract gDNA</a></li>
                   <li><a href="/process/gdna_compression">Compress gDNA plates</a></li>

--- a/labman/gui/test/test_plate.py
+++ b/labman/gui/test/test_plate.py
@@ -6,6 +6,7 @@
 # The full license is in the file LICENSE, distributed with this software.
 # ----------------------------------------------------------------------------
 
+from json import dumps
 from unittest import main
 
 from tornado.escape import json_decode
@@ -214,6 +215,27 @@ class TestPlateHandlers(TestHandlerBase):
                         'vibrio.positive.control.21.G2', 'notes': None})
         self.assertEqual(obs[7][4], {'sample': 'blank.21.H5', 'notes': None})
 
+    def test_get_plate_search_handler(self):
+        response = self.get('/plate_search')
+        self.assertEqual(response.code, 200)
+        self.assertNotEqual(response.body, '')
+
+    def test_post_plate_search_handler(self):
+        pass
+        # # TODO: This test needs to be filled in by someone who knows what samples/etc the test database will hold
+        # post_data = {
+        #     'sample_names': dumps(sampleNames),
+        #     'plate_comment_keywords': plate_comment_keywords,
+        #     'well_comment_keywords': well_comment_keywords,
+        #     'operation': "INTERSECT"
+        # }
+        # response = self.post('/plate_search', post_data)
+        # self.assertEqual(response.code, 200)
+        # obs = json_decode(response.body)
+        # self.assertCountEqual(obs.keys(), ['data'])
+        # obs_data = obs['data']
+        # self.assertEqual(len(obs_data), 1)
+        # self.assertEqual(obs_data[0], [21, 'Test plate 1'])
 
 if __name__ == '__main__':
     main()

--- a/labman/gui/webserver.py
+++ b/labman/gui/webserver.py
@@ -16,7 +16,7 @@ from labman.gui.handlers.base import IndexHandler, NotFoundHandler
 from labman.gui.handlers.auth import LoginHandler, LogoutHandler
 from labman.gui.handlers.plate import (
     PlateMapHandler, PlateNameHandler, PlateHandler, PlateLayoutHandler,
-    PlateListHandler, PlateListingHandler)
+    PlateSearchHandler, PlateListHandler, PlateListingHandler)
 from labman.gui.handlers.pool import (
     PoolListHandler, PoolHandler, PoolListingHandler)
 from labman.gui.handlers.study import (
@@ -45,6 +45,7 @@ class Application(tornado.web.Application):
                     (r"/plate/(.*)/layout", PlateLayoutHandler),
                     (r"/plate/(.*)/", PlateHandler),
                     (r"/plates$", PlateListingHandler),
+                    (r"/plate_search", PlateSearchHandler),
                     (r"/plate$", PlateMapHandler),
                     (r"/platename", PlateNameHandler),
                     # Pool handlers


### PR DESCRIPTION
Implements functionality for #76

However, here's what's missing:
1) verification that the call in plate.py to Plate.search works, as that function has been written but not yet merged into main
2) implementation of requirement that user should not be able to enter samples to search without first adding at least one study to search (code currently lets users search ALL studies)

Additionally, I suggest that there should be another validation added: currently the javascript ensures that at least one sample input has been added--but doesn't verify that the sample input has a non-empty-string value.  D'oh :)