### PR TITLE
Sequence run list interface

### DIFF
--- a/labman/db/process.py
+++ b/labman/db/process.py
@@ -2092,7 +2092,6 @@ class SequencingProcess(Process):
         'HiSeq4000': 8, 'HiSeq3000': 8, 'HiSeq2500': 2, 'HiSeq1500': 2,
         'MiSeq': 1, 'MiniSeq': 1, 'NextSeq': 1, 'NovaSeq': 1}
 
-
     @staticmethod
     def list_sequencing_runs():
         """Generates a list of sequencing runs
@@ -2109,7 +2108,6 @@ class SequencingProcess(Process):
                      ORDER BY process_id"""
             TRN.add(sql)
             return [dict(r) for r in TRN.execute_fetchindex()]
-
 
     @classmethod
     def create(cls, user, pools, run_name, experiment, sequencer,

--- a/labman/db/process.py
+++ b/labman/db/process.py
@@ -1906,6 +1906,25 @@ class SequencingProcess(Process):
         'HiSeq4000': 8, 'HiSeq3000': 8, 'HiSeq2500': 2, 'HiSeq1500': 2,
         'MiSeq': 1, 'MiniSeq': 1, 'NextSeq': 1, 'NovaSeq': 1}
 
+
+    @staticmethod
+    def list_sequencing_runs():
+        """Generates a list of sequencing runs
+
+        Returns
+        -------
+        list of dicts
+            The list of sequence run information with the structure:
+            [{'process_id': int, 'run_name': string, ...}]
+        """
+        with sql_connection.TRN as TRN:
+            sql = """SELECT *
+                        FROM qiita.sequencing_process
+                     ORDER BY process_id"""
+            TRN.add(sql)
+            return [dict(r) for r in TRN.execute_fetchindex()]
+
+
     @classmethod
     def create(cls, user, pools, run_name, experiment, sequencer,
                fwd_cycles, rev_cycles, principal_investigator,

--- a/labman/db/tests/test_process.py
+++ b/labman/db/tests/test_process.py
@@ -973,6 +973,28 @@ class TestSequencingProcess(LabmanTestCase):
             [User('admin@foo.bar'), User('demo@microbio.me'),
              User('shared@foo.bar')])
 
+    def test_list_sequencing_runs(self):
+        obs = SequencingProcess.list_sequencing_runs()
+
+        self.assertEqual(obs[0], {'process_id': 16,
+                                  'run_name': 'Test Run.1',
+                                  'sequencing_process_id': 1,
+                                  'experiment': 'TestExperiment1',
+                                  'sequencer_id': 18,
+                                  'fwd_cycles': 151,
+                                  'rev_cycles': 151,
+                                  'assay': 'Amplicon',
+                                  'principal_investigator': 'test@foo.bar'})
+        self.assertEqual(obs[1], {'process_id': 23,
+                                  'run_name': 'TestShotgunRun1',
+                                  'sequencing_process_id': 2,
+                                  'experiment': 'TestExperimentShotgun1',
+                                  'sequencer_id': 19,
+                                  'fwd_cycles': 151,
+                                  'rev_cycles': 151,
+                                  'assay': 'Metagenomics',
+                                  'principal_investigator': 'test@foo.bar'})
+
     def test_create(self):
         user = User('test@foo.bar')
         pool = PoolComposition(2)

--- a/labman/gui/handlers/sequence.py
+++ b/labman/gui/handlers/sequence.py
@@ -6,11 +6,9 @@
 # The full license is in the file LICENSE, distributed with this software.
 # ----------------------------------------------------------------------------
 
-from tornado.web import authenticated, HTTPError
-from tornado.escape import json_decode
+from tornado.web import authenticated
 
 from labman.gui.handlers.base import BaseHandler
-from labman.db.exceptions import LabmanUnknownIdError
 from labman.db.process import SequencingProcess
 
 

--- a/labman/gui/handlers/sequence.py
+++ b/labman/gui/handlers/sequence.py
@@ -1,0 +1,48 @@
+# ----------------------------------------------------------------------------
+# Copyright (c) 2017-, labman development team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file LICENSE, distributed with this software.
+# ----------------------------------------------------------------------------
+
+from tornado.web import authenticated, HTTPError
+from tornado.escape import json_decode
+
+from labman.gui.handlers.base import BaseHandler
+from labman.db.exceptions import LabmanUnknownIdError
+from labman.db.process import SequencingProcess
+
+
+class SequenceRunListingHandler(BaseHandler):
+    @authenticated
+    def get(self):
+        self.render('sequence_run_list.html')
+
+
+class SequenceRunListHandler(BaseHandler):
+    @authenticated
+    def get(self):
+        res = {"data": [[p['process_id'],
+                         p['run_name'],
+                         p['experiment'],
+                         p['assay'],
+                         p['principal_investigator'],
+                         p['sequencing_process_id']]
+                        for p in SequencingProcess.list_sequencing_runs()]}
+        self.write(res)
+
+
+class SequenceRunHandler(BaseHandler):
+    @authenticated
+    def get(self, pool_id):
+        try:
+            pool = PoolComposition(int(pool_id))
+        except LabmanUnknownIdError:
+            raise HTTPError(404, 'Pool %s doesn\'t exist' % pool_id)
+
+        result = {'pool_id': pool.id,
+                  'pool_name': pool.container.external_id,
+                  'num_components': len(pool.components)}
+        self.write(result)
+        self.finish()

--- a/labman/gui/templates/sequence_run_list.html
+++ b/labman/gui/templates/sequence_run_list.html
@@ -1,0 +1,45 @@
+{% extends sitebase.html %}
+{% block head %}
+<script type='text/javascript'>
+
+  $(document).ready(function(){
+    var table = $('#sequenceRunListTable').DataTable(
+      {'columnDefs': [{'targets': 0, 'orderable': false, 'width': '150px'}],
+       'order': [[1, "desc"]],
+       'language': {'zeroRecords': 'No sequencing runs found'}});
+    $.get('/sequence_run_list', function(data) {
+      var datatable = $('#sequenceRunListTable').DataTable();
+      var newData = [];
+      for (var row of data.data) {
+        var sampleSheet = "<a href='/process/sequencing/" + row[5] + 
+          "/sample_sheet' class='btn btn-success'>" +
+          "<span class='glyphicon glyphicon-download'></span> " +
+          "Download Sample Sheet</a>"
+        newData.push([row[0], row[1], row[2], row[3], row[4], sampleSheet]);
+      }
+      datatable.clear();
+      datatable.rows.add(newData);
+      datatable.draw();
+    });
+  });
+</script>
+{% end %}
+{%block content %}
+
+<label><h3>Sequence run list</h3></label>
+
+<table id="sequenceRunListTable" class="display" cellspacing="0" width="100%">
+  <thead>
+    <tr>
+      <th>Sequence run id</th>
+      <th>Run name</th>
+      <th>Experiment</th>
+      <th>Assay</th>
+      <th>PI</th>
+      <th>Sample sheet</th>
+    </tr>
+  </thead>
+</table>
+
+<div id='btn-div'></div>
+{% end %}

--- a/labman/gui/templates/sitebase.html
+++ b/labman/gui/templates/sitebase.html
@@ -68,6 +68,7 @@
               <li class="dropdown">
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Sequencing runs <span class="caret"></span></a>
                 <ul class="dropdown-menu">
+                  <li><a href="/sequence_runs">List</a></li>
                   <li><a href="/process/sequencing">Prepare sequencing run</a></li>
                 </ul>
               </li>

--- a/labman/gui/test/test_sequence_run.py
+++ b/labman/gui/test/test_sequence_run.py
@@ -1,0 +1,47 @@
+# ----------------------------------------------------------------------------
+# Copyright (c) 2017-, labman development team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file LICENSE, distributed with this software.
+# ----------------------------------------------------------------------------
+
+from unittest import main
+
+from tornado.escape import json_decode
+
+from labman.gui.testing import TestHandlerBase
+
+
+class TestSequenceRunListHandler(TestHandlerBase):
+    def test_get(self):
+        response = self.get('/sequence_run_list')
+
+        self.assertEqual(response.code, 200)
+        obs = json_decode(response.body)
+        exp = {'data': [[16,
+                         'Test Run.1',
+                         'TestExperiment1',
+                         'Amplicon',
+                         'test@foo.bar',
+                         1],
+                        [23,
+                         'TestShotgunRun1',
+                         'TestExperimentShotgun1',
+                         'Metagenomics',
+                         'test@foo.bar',
+                         2]]}
+        self.assertEqual(obs, exp)
+
+
+class TestSequenceRunListingHandler(TestHandlerBase):
+    def test_get(self):
+        response = self.get('/sequence_runs')
+        
+        self.assertEqual(response.code, 200)
+
+        self.assertIn('Sequence run id', response.body.decode('utf8'))
+
+
+if __name__ == '__main__':
+    main()

--- a/labman/gui/test/test_sequence_run.py
+++ b/labman/gui/test/test_sequence_run.py
@@ -37,9 +37,8 @@ class TestSequenceRunListHandler(TestHandlerBase):
 class TestSequenceRunListingHandler(TestHandlerBase):
     def test_get(self):
         response = self.get('/sequence_runs')
-        
-        self.assertEqual(response.code, 200)
 
+        self.assertEqual(response.code, 200)
         self.assertIn('Sequence run id', response.body.decode('utf8'))
 
 

--- a/labman/gui/webserver.py
+++ b/labman/gui/webserver.py
@@ -21,6 +21,8 @@ from labman.gui.handlers.pool import (
     PoolListHandler, PoolHandler, PoolListingHandler)
 from labman.gui.handlers.study import (
     StudyListHandler, StudyHandler, StudySamplesHandler)
+from labman.gui.handlers.sequence import (
+    SequenceRunListingHandler, SequenceRunListHandler, SequenceRunHandler)
 from labman.gui.handlers.sample import ControlSamplesHandler
 from labman.gui.handlers.process_handlers import PROCESS_ENDPOINTS
 from labman.gui.handlers.composition_handlers import COMPOSITION_ENDPOINTS
@@ -51,6 +53,10 @@ class Application(tornado.web.Application):
                     (r"/pool_list$", PoolListHandler),
                     (r"/pool/(.*)/", PoolHandler),
                     (r"/pools$", PoolListingHandler),
+                    # Sequence handlers
+                    (r"/sequence_run_list$", SequenceRunListHandler),
+                    (r"/sequence_run/(.*)/", SequenceRunHandler),
+                    (r"/sequence_runs$", SequenceRunListingHandler),
                     # Study handlers
                     (r"/study_list", StudyListHandler),
                     (r"/study/(.*)/samples", StudySamplesHandler),


### PR DESCRIPTION
Adds interface page for listing sequence runs. 

Rather than redirecting to webpage for sample sheet download, we've just exposed relevant variables in the table and provided download links in the table itself. 