### PR TITLE
ENH: Download preparations for a sequencing run

### DIFF
--- a/labman/gui/handlers/process_handlers/__init__.py
+++ b/labman/gui/handlers/process_handlers/__init__.py
@@ -19,7 +19,8 @@ from .pooling_process import (
     PoolPoolProcessHandler, LibraryPoolProcessHandler,
     ComputeLibraryPoolValueslHandler, DownloadPoolFileHandler)
 from .sequencing_process import (
-    SequencingProcessHandler, DownloadSampleSheetHandler)
+    SequencingProcessHandler, DownloadSampleSheetHandler,
+    DownloadPreparationSheetsHandler)
 from .normalization_process import (
     NormalizationProcessHandler, DownloadNormalizationProcessHandler)
 from .primer_working_plate_creation_process import (
@@ -31,6 +32,7 @@ __all__ = ['SamplePlatingProcessListHandler', 'SamplePlatingProcessHandler',
            'QuantificationProcessParseHandler', 'QuantificationProcessHandler',
            'PoolPoolProcessHandler', 'LibraryPoolProcessHandler',
            'SequencingProcessHandler', 'DownloadSampleSheetHandler',
+           'DownloadPreparationSheetsHandler',
            'GDNAPlateCompressionProcessHandler',
            'PrimerWorkingPlateCreationProcessHandler',
            'EquipmentCreationProcessHandler',
@@ -55,6 +57,8 @@ PROCESS_ENDPOINTS = [
      DownloadLibraryPrepShotgunProcessHandler),
     (r"/process/sequencing/([0-9]+)/sample_sheet$",
      DownloadSampleSheetHandler),
+    (r"/process/sequencing/([0-9]+)/preparation_sheets$",
+     DownloadPreparationSheetsHandler),
     (r"/process/normalize$", NormalizationProcessHandler),
     (r"/process/normalize/([0-9]+)/echo_pick_list$",
      DownloadNormalizationProcessHandler),

--- a/labman/gui/handlers/process_handlers/sequencing_process.py
+++ b/labman/gui/handlers/process_handlers/sequencing_process.py
@@ -7,6 +7,9 @@
 # ----------------------------------------------------------------------------
 
 import re
+import zipfile
+
+from io import BytesIO
 
 from tornado.web import authenticated
 from tornado.escape import json_decode
@@ -65,4 +68,31 @@ class DownloadSampleSheetHandler(BaseHandler):
         self.set_header('Content-Disposition',
                         'attachment; filename=%s' % filename)
         self.write(text)
+        self.finish()
+
+class DownloadPreparationSheetsHandler(BaseHandler):
+    @authenticated
+    def get(self, process_id):
+        process = SequencingProcess(int(process_id))
+
+        with BytesIO() as content:
+
+            with zipfile.ZipFile(content, mode='w',
+                                 compression=zipfile.ZIP_DEFLATED) as zf:
+                for study, prep in process.generate_prep_information().items():
+                    name = 'PrepSheet_process_%s_study_%s.csv' % (process.id,
+                                                                  study.id)
+                    zf.writestr(name, prep)
+
+            zip_name = (re.sub('[^0-9a-zA-Z\-\_]+', '_', process.run_name) +
+                        '_PrepSheets.zip')
+
+            self.set_header('Content-Type', 'application/zip')
+            self.set_header('Expires', '0')
+            self.set_header('Cache-Control', 'no-cache')
+            self.set_header("Content-Disposition", "attachment; filename=%s" %
+                            zip_name)
+
+            self.write(content.getvalue())
+
         self.finish()

--- a/labman/gui/handlers/process_handlers/sequencing_process.py
+++ b/labman/gui/handlers/process_handlers/sequencing_process.py
@@ -70,6 +70,7 @@ class DownloadSampleSheetHandler(BaseHandler):
         self.write(text)
         self.finish()
 
+
 class DownloadPreparationSheetsHandler(BaseHandler):
     @authenticated
     def get(self, process_id):

--- a/labman/gui/handlers/process_handlers/test/test_sequencing_process.py
+++ b/labman/gui/handlers/process_handlers/test/test_sequencing_process.py
@@ -35,5 +35,11 @@ class TestSequencingProcessHandler(TestHandlerBase):
         self.assertTrue(response.body.startswith(b'# PI,Dude,test@foo.bar\n'))
 
 
+    def test_get_download_preparation_sheet_handler(self):
+        response = self.get('process/sequencing/1/preparation_sheets')
+
+        self.assertNotEqual(response.body, '')
+
+
 if __name__ == '__main__':
     main()

--- a/labman/gui/handlers/process_handlers/test/test_sequencing_process.py
+++ b/labman/gui/handlers/process_handlers/test/test_sequencing_process.py
@@ -6,6 +6,9 @@
 # The full license is in the file LICENSE, distributed with this software.
 # ----------------------------------------------------------------------------
 
+import zipfile
+
+from io import BytesIO
 from unittest import main
 from tornado.escape import json_encode, json_decode
 
@@ -36,7 +39,7 @@ class TestSequencingProcessHandler(TestHandlerBase):
         self.assertTrue(response.body.startswith(b'# PI,Dude,test@foo.bar\n'))
 
     def test_get_download_preparation_sheet_handler(self):
-        response = self.get('process/sequencing/1/preparation_sheets')
+        response = self.get('/process/sequencing/1/preparation_sheets')
         self.assertNotEqual(response.body, '')
         self.assertEqual(response.code, 200)
 
@@ -44,7 +47,11 @@ class TestSequencingProcessHandler(TestHandlerBase):
         self.assertEqual(response.headers['Expires'], '0')
         self.assertEqual(response.headers['Cache-Control'], 'no-cache')
         self.assertEqual(response.headers['Content-Disposition'],
-                         'attachment; filename=')
+                         'attachment; filename=Test_Run_1_PrepSheets.zip')
+
+        archive = zipfile.ZipFile(BytesIO(response.body), 'r')
+        contents = archive.open('PrepSheet_process_1_study_1.csv').read()
+        self.assertNotEqual(contents, '')
 
 
 if __name__ == '__main__':

--- a/labman/gui/handlers/process_handlers/test/test_sequencing_process.py
+++ b/labman/gui/handlers/process_handlers/test/test_sequencing_process.py
@@ -32,13 +32,19 @@ class TestSequencingProcessHandler(TestHandlerBase):
     def test_get_download_sample_sheet_handler(self):
         response = self.get('/process/sequencing/1/sample_sheet')
         self.assertNotEqual(response.body, '')
+        self.assertEqual(response.code, 200)
         self.assertTrue(response.body.startswith(b'# PI,Dude,test@foo.bar\n'))
-
 
     def test_get_download_preparation_sheet_handler(self):
         response = self.get('process/sequencing/1/preparation_sheets')
-
         self.assertNotEqual(response.body, '')
+        self.assertEqual(response.code, 200)
+
+        self.assertEqual(response.headers['Content-Type'], 'application/zip')
+        self.assertEqual(response.headers['Expires'], '0')
+        self.assertEqual(response.headers['Cache-Control'], 'no-cache')
+        self.assertEqual(response.headers['Content-Disposition'],
+                         'attachment; filename=')
 
 
 if __name__ == '__main__':

--- a/labman/gui/templates/sequence_run_list.html
+++ b/labman/gui/templates/sequence_run_list.html
@@ -11,11 +11,17 @@
       var datatable = $('#sequenceRunListTable').DataTable();
       var newData = [];
       for (var row of data.data) {
-        var sampleSheet = "<a href='/process/sequencing/" + row[5] + 
+        var sampleSheet = "<a href='/process/sequencing/" + row[5] +
           "/sample_sheet' class='btn btn-success'>" +
           "<span class='glyphicon glyphicon-download'></span> " +
-          "Download Sample Sheet</a>"
-        newData.push([row[0], row[1], row[2], row[3], row[4], sampleSheet]);
+          "Download Sample Sheet</a>";
+        var preparationSheets = "<a href='/process/sequencing/" + row[5] +
+          "/preparation_sheets' class='btn btn-success'>" +
+          "<span class='glyphicon glyphicon-download'></span> " +
+          "Download Preparation Sheets</a>";
+
+        newData.push([row[0], row[1], row[2], row[3], row[4], sampleSheet,
+                      preparationSheets]);
       }
       datatable.clear();
       datatable.rows.add(newData);
@@ -37,6 +43,7 @@
       <th>Assay</th>
       <th>PI</th>
       <th>Sample sheet</th>
+      <th>Preparation sheets</th>
     </tr>
   </thead>
 </table>


### PR DESCRIPTION
Adds a handler that creates a zip file with all the preparation files
for a given sequencing identifier. Also adds a button in the template
so users can download the data from the sequencing list table.

One thing I couldn't get around was that when running the test suite, the response's code was always 599, regardless of the URI (even endpoints that already existed). I couldn't test much, only via the UI. It would be good if someone can shed some light as to what else I can do, or if I'm missing something (maybe because of my local installation).

Fixes #86 
