### PR TITLE
ENH: Makes edit/selection modes more amenable

### DIFF
--- a/labman/gui/static/css/labman.css
+++ b/labman/gui/static/css/labman.css
@@ -152,3 +152,11 @@ background-color: white;
 .popup .show {
     visibility: visible;
 }
+
+/* Make key tags look like buttons, from: */
+/* https://developer.mozilla.org/en-US/docs/Web/HTML/Element/kbd */
+kbd.key {
+  border-radius: 3px;
+  padding: 1px 2px 0;
+  border: 1px solid black;
+}

--- a/labman/gui/static/js/plateViewer.js
+++ b/labman/gui/static/js/plateViewer.js
@@ -147,6 +147,11 @@ PlateViewer.prototype.initialize = function (rows, cols) {
         that._undoRedoBuffer.undo();
       }
     }
+    // ESC enters selection mode, so autoEdit should be turned off to allow
+    // users to navigate between cells with the arrow keys
+    if (e.keyCode === 27) {
+      that.grid.setOptions({autoEdit: false});
+    }
   });
 
   var pluginOptions = {
@@ -439,11 +444,11 @@ function SampleCellEditor(args) {
               'margin':'0',
               'background': 'transparent',
               'outline': '0',
-              'padding': '0'})
-        .focus()
-        .select();
+              'padding': '0'});
 
     $input.autocomplete({source: autocomplete_search_samples});
+
+    args.grid.setOptions({autoEdit: true});
   };
 
   this.destroy = function () {

--- a/labman/gui/templates/plate.html
+++ b/labman/gui/templates/plate.html
@@ -135,7 +135,8 @@
 
 <!-- Controls div -->
 <div class='popup' onclick='show_popup()'><h5>Controls description</h5>
-  <span>Press ESC to enter cell selection mode</span>
+  <p>Press <kbd class='key'>ESC</kbd> to enter cell <i>selection mode</i></p>
+  <p>Press <kbd class='key'>ENTER</kbd> or double click a cell to enter <i>edit mode</i></p>
   <span class='popuptext' id='controls_description'>
     <table>
       <tr>


### PR DESCRIPTION
Once users enter selection mode, auto editing is turned off so that
users can navigate the grid with the arrow keys. Also added some extra
formatting for the help text of the grid.