### PR TITLE
Add undo/redo functionality

### DIFF
--- a/labman/gui/static/js/plateViewer.js
+++ b/labman/gui/static/js/plateViewer.js
@@ -82,11 +82,6 @@ PlateViewer.prototype.initialize = function (rows, cols) {
   this.wellPreviousPlates = [];
   this.wellClasses = [];
 
-  var sgOptions = {editable: true,
-                   enableCellNavigation: true,
-                   asyncEditorLoading: false,
-                   enableColumnReorder: false,
-                   autoEdit: true};
   var sgCols = [{id: 'selector', name: '', field: 'header', width: 30}]
   for (var i = 0; i < this.cols; i++) {
     // We need to add the plate Viewer as an element of this list so it gets
@@ -138,6 +133,17 @@ PlateViewer.prototype.initialize = function (rows, cols) {
           command.execute();
         }
       }
+  };
+
+  var sgOptions = {
+    editable: true,
+    enableCellNavigation: true,
+    asyncEditorLoading: false,
+    enableColumnReorder: false,
+    autoEdit: true,
+    editCommandHandler: function(item, column, editCommand) {
+     that._undoRedoBuffer.queueAndExecuteCommand(editCommand);
+    }
   };
 
   // Handle the callbacks to CTRL + Z and CTRL + SHIFT + Z


### PR DESCRIPTION
Seems to be working now, except blank cells are saved with a blank placeholder i.e. if you paste 4 cells with no content, the grid will turn these into "blank entries". It's rather strange, before merging I recommend that you try this out locally. 

Fixes #120