### PR TITLE
ENH: Add discard plate functionality

### DIFF
--- a/labman/db/plate.py
+++ b/labman/db/plate.py
@@ -171,7 +171,8 @@ class Plate(base.LabmanObject):
         return res
 
     @staticmethod
-    def list_plates(plate_types=None, only_quantified=False):
+    def list_plates(plate_types=None, only_quantified=False,
+                    include_discarded=False):
         """Generates a list of plates with some information about them
 
         Parameters
@@ -181,6 +182,9 @@ class Plate(base.LabmanObject):
         only_quantified: bool, optional
             If true, return only those plates that have been quantified
             Default: false.
+        include_discarded: bool, optional
+            If true, plates that have been marked as discarded will be
+            included in this list, otherwise they won't.
 
         Returns
         -------
@@ -189,14 +193,29 @@ class Plate(base.LabmanObject):
             [{'plate_id': int, 'external_id': string}]
         """
         with sql_connection.TRN as TRN:
-            # Not using if plate_type is not None cause I also want to cover
-            # the case in which the list is empty
-            sql_where = ''
+            sql_where, sql_discard, sql_plate_types = '', '', ''
             sql_args = []
             sql_join = ''
+
+            # do not include discarded plates
+            if not include_discarded:
+                sql_discard = 'discarded = FALSE '
+
+            # Not using if plate_type is not None cause I also want to cover
+            # the case in which the list is empty
             if plate_types:
-                sql_where = 'WHERE description IN %s'
+                sql_plate_types = 'description IN %s'
                 sql_args.append(tuple(plate_types))
+
+            # The WHERE clause is only needed if we have to filter plates
+            # (which may depend on multiple conditions)
+            if sql_discard != '' or sql_plate_types != '':
+                sql_where = 'WHERE '
+                if sql_discard != '' and sql_plate_types != '':
+                    sql_where += sql_discard + ' AND ' + sql_plate_types
+                else:
+                    sql_where += sql_discard + ' ' + sql_plate_types
+
             if only_quantified:
                 sql_join = ("JOIN qiita.concentration_calculation "
                             "ON quantitated_composition_id = composition_id")
@@ -276,6 +295,11 @@ class Plate(base.LabmanObject):
     def discarded(self):
         """Whether the plate is discarded or not"""
         return self._get_attr('discarded')
+
+    @discarded.setter
+    def discarded(self, value):
+        """Updates the discarded status of the plate"""
+        self._set_attr('discarded', value)
 
     @property
     def notes(self):

--- a/labman/db/tests/test_plate.py
+++ b/labman/db/tests/test_plate.py
@@ -161,6 +161,69 @@ class TestPlate(LabmanTestCase):
             obs, [{'plate_id': 24,
                    'external_id': 'Test compressed gDNA plate 1'}])
 
+    def test_plate_list_discarded_functionality(self):
+        # test case based on the test_list_plates
+        obs = Plate.list_plates()
+        Plate(21).discard = True
+        self.assertGreaterEqual(len(obs), 25)
+        self.assertEqual(obs[0], {'plate_id': 1,
+                                  'external_id': 'EMP 16S V4 primer plate 1'})
+        self.assertEqual(
+            obs[16], {'plate_id': 17,
+                      'external_id': 'EMP 16S V4 primer plate 7 10/23/2017'})
+        self.assertEqual(obs[20], {'plate_id': 21,
+                                   'external_id': 'Test plate 1'})
+        Plate(21).discard = False
+
+        # Test without returning discarded primer plates
+        Plate(11).discarded = True
+        Plate(12).discarded = True
+        Plate(13).discarded = True
+        obs = Plate.list_plates(['primer'], include_discarded=False)
+
+        exp = [
+            {'plate_id': 14,
+             'external_id': 'EMP 16S V4 primer plate 4 10/23/2017'},
+            {'plate_id': 15,
+             'external_id': 'EMP 16S V4 primer plate 5 10/23/2017'},
+            {'plate_id': 16,
+             'external_id': 'EMP 16S V4 primer plate 6 10/23/2017'},
+            {'plate_id': 17,
+             'external_id': 'EMP 16S V4 primer plate 7 10/23/2017'},
+            {'plate_id': 18,
+             'external_id': 'EMP 16S V4 primer plate 8 10/23/2017'},
+            {'plate_id': 19, 'external_id': 'iTru 5 Primer Plate 10/23/2017'},
+            {'plate_id': 20, 'external_id': 'iTru 7 Primer Plate 10/23/2017'}]
+        self.assertEqual(obs, exp)
+
+        # Test returning discarded primer plates
+        obs = Plate.list_plates(['primer'], include_discarded=True)
+        exp = [
+            {'plate_id': 11,
+             'external_id': 'EMP 16S V4 primer plate 1 10/23/2017'},
+            {'plate_id': 12,
+             'external_id': 'EMP 16S V4 primer plate 2 10/23/2017'},
+            {'plate_id': 13,
+             'external_id': 'EMP 16S V4 primer plate 3 10/23/2017'},
+            {'plate_id': 14,
+             'external_id': 'EMP 16S V4 primer plate 4 10/23/2017'},
+            {'plate_id': 15,
+             'external_id': 'EMP 16S V4 primer plate 5 10/23/2017'},
+            {'plate_id': 16,
+             'external_id': 'EMP 16S V4 primer plate 6 10/23/2017'},
+            {'plate_id': 17,
+             'external_id': 'EMP 16S V4 primer plate 7 10/23/2017'},
+            {'plate_id': 18,
+             'external_id': 'EMP 16S V4 primer plate 8 10/23/2017'},
+            {'plate_id': 19, 'external_id': 'iTru 5 Primer Plate 10/23/2017'},
+            {'plate_id': 20, 'external_id': 'iTru 7 Primer Plate 10/23/2017'}]
+        self.assertEqual(obs, exp)
+
+        # undo the discarding
+        Plate(11).discarded = False
+        Plate(12).discarded = False
+        Plate(13).discarded = False
+
     def test_external_id_exists(self):
         self.assertTrue(Plate.external_id_exists('Test plate 1'))
         self.assertFalse(Plate.external_id_exists('This is a new name'))
@@ -185,6 +248,8 @@ class TestPlate(LabmanTestCase):
         self.assertEqual(tester.external_id, 'Test plate 1')
         self.assertEqual(tester.plate_configuration, PlateConfiguration(1))
         self.assertFalse(tester.discarded)
+        tester.discarded = True
+        self.assertTrue(tester.discarded)
         self.assertIsNone(tester.notes)
         obs_layout = tester.layout
         self.assertEqual(len(obs_layout), 8)

--- a/labman/gui/handlers/plate.py
+++ b/labman/gui/handlers/plate.py
@@ -155,6 +155,8 @@ def plate_handler_patch_request(user, plate_id, req_op, req_path,
         attribute = req_path[0]
         if attribute == 'name':
             plate.external_id = req_value
+        elif attribute == 'discarded':
+            plate.discarded = req_value
         else:
             raise HTTPError(404, 'Attribute %s not recognized' % attribute)
     else:

--- a/labman/gui/templates/plate_list.html
+++ b/labman/gui/templates/plate_list.html
@@ -40,9 +40,39 @@
     });
   };
 
+  /**
+   *
+   * Callback to discard a plate
+   *
+   * @param {Integer} id The identifier of the plate to discard.
+   * @param {Node} node The HTML object that originated the callback i.e. the
+   * delete button.
+   */
+  function discardPlate(id, node) {
+    var $node = $(node), $table;
+    $node.addClass('disabled');
+
+    $.ajax({
+      url: 'plate/' + id + '/',
+      type: 'PATCH',
+      data: {op: 'replace', path: '/discarded/', value: true},
+      success: function(data, textStatus, request) {
+        // taken from: https://datatables.net/reference/api/row().remove()
+        $table = $('#plateListTable').DataTable()
+        $table.row($node.parents('tr')).remove().draw();
+      },
+      error: function(request, stat, error) {
+        $node.removeClass('disabled');
+        bootstrapAlert(error + ': ' + request.responseText );
+      }
+    });
+  }
+
   $(document).ready(function(){
     var table = $('#plateListTable').DataTable(
-      {'columnDefs': [{'targets': 0, 'orderable': false, 'width': '50px'}],
+      {'columnDefs': [
+        {'targets': 0, 'orderable': false, 'width': '50px'},
+        {'targets': 4, 'orderable': false, 'width': '50px', 'className': 'text-right'}],
        'order': [[1, "desc"]],
        'language': {'zeroRecords': 'No plates found - choose a plate type'}});
 
@@ -64,7 +94,11 @@
                         '<span class="glyphicon glyphicon-eye-open" data-toggle="tooltip" title="View plate process"></span>' +
                        '</a> ' +
                        '<input type="checkbox" class="table-checkbox" data-lb-plate-id="' + row[0] + '"></input>');
-          newData.push([chBox, row[0], row[1], row[2].join('<br/>')]);
+
+          var deleteButton = '<a onclick="discardPlate(' + row[0] + ', this)" class="btn btn-danger btn-circle-small">' +
+                               '<span class="glyphicon glyphicon-remove" data-toggle="tooltip" title="Remove plate"></span>' +
+                             '</a> ';
+          newData.push([chBox, row[0], row[1], row[2].join('<br/>'), deleteButton]);
         }
         datatable.clear();
         datatable.rows.add(newData);
@@ -117,6 +151,7 @@
       <th>Plate id</th>
       <th>Plate name</th>
       <th>Studies</th>
+      <th></th>
     </tr>
   </thead>
 </table>

--- a/labman/gui/test/test_plate.py
+++ b/labman/gui/test/test_plate.py
@@ -80,6 +80,12 @@ class TestUtils(TestHandlerBase):
         self.assertEqual(tester.external_id, 'NewName')
         tester.external_id = 'Test plate 1'
 
+        # Test success - discarded
+        plate_handler_patch_request(user, 21, 'replace', '/discarded/',
+                                    True, None)
+        self.assertEqual(tester.discarded, True)
+        tester.discarded = False
+
     def test_plate_layout_handler_get_request(self):
         obs = plate_layout_handler_get_request(21)
         self.assertEqual(len(obs), 8)
@@ -285,6 +291,14 @@ class TestPlateHandlers(TestHandlerBase):
         self.assertEqual(response.code, 200)
         self.assertEqual(tester.external_id, 'NewName')
         tester.external_id = 'Test plate 1'
+
+    def test_patch_plate_discarded_handler(self):
+        tester = Plate(21)
+        data = {'op': 'replace', 'path': '/discarded/', 'value': True}
+        response = self.patch('/plate/21/', data)
+        self.assertEqual(response.code, 200)
+        self.assertEqual(tester.discarded, True)
+        tester.discarded = False
 
     def test_get_plate_layout_handler(self):
         response = self.get('/plate/21/layout')


### PR DESCRIPTION
This patch makes two additions to the Plate class, first it adds a
"discarded" setter, and second it extends the functionality in the
list_plates method to be able to retrieve (or not) plates that have been
marked as discarded.

The PATCH handler is now aware about the discarded property. The UI uses
this route to make changes from the plate list. I've done some error handling using the bootstrapAlert function to handle the case where a "deletion" fails, not sure if something else is preferable.

Fixes #150