### PR TITLE
Allow users to download all the plate maps of a study

### DIFF
--- a/labman/db/container.py
+++ b/labman/db/container.py
@@ -16,6 +16,26 @@ from . import composition as composition_module
 LETTERS = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'
 
 
+def generate_row_id(row):
+    """Generates the row id from the row number (e.g. 1 -> A, 2 -> B)
+
+    Parameters
+    ----------
+    row: int
+        The row number
+
+    Returns
+    -------
+    str
+    """
+    # Adapted from https://stackoverflow.com/a/19169180/3746629
+    result = []
+    while row:
+        row, rem = divmod(row-1, 26)
+        result[:0] = LETTERS[rem]
+    return ''.join(result)
+
+
 class Container(base.LabmanObject):
     """Container object
 
@@ -271,9 +291,4 @@ class Well(Container):
         """The well id in the "A1","H12" form"""
         row = self.row
         col = self.column
-        # Adapted from https://stackoverflow.com/a/19169180/3746629
-        result = []
-        while row:
-            row, rem = divmod(row-1, 26)
-            result[:0] = LETTERS[rem]
-        return ''.join(result) + str(col)
+        return generate_row_id(row) + str(col)

--- a/labman/db/process.py
+++ b/labman/db/process.py
@@ -22,7 +22,7 @@ from . import plate as plate_module
 from . import container as container_module
 from . import composition as composition_module
 from . import equipment as equipment_module
-from .study import Study
+from . import study as study_module
 
 
 class Process(base.LabmanObject):
@@ -3056,7 +3056,7 @@ class SequencingProcess(Process):
                     result.pop('platform_id')]['description']
 
                 if sid is not None and study_id is not None:
-                    study = Study(study_id)
+                    study = study_module.Study(study_id)
                     if study not in data:
                         data[study] = {}
                     data[study][content] = result

--- a/labman/db/tests/test_study.py
+++ b/labman/db/tests/test_study.py
@@ -82,6 +82,52 @@ class TestStudy(LabmanTestCase):
         exp_samples = ['1.SKB1.640202', '1.SKD1.640179', '1.SKM1.640183']
         self.assertEqual(s.samples('1.64'), exp_samples)
 
+    def test_generate_sample_plate_maps(self):
+        obs = Study(1).generate_sample_plate_maps()
+        exp = (
+            'Plate "Test plate 1" (ID: 21)\n'
+            ',1,2,3,4,5,6,7,8,9,10,11,12\n'
+            'A,1.SKB1.640202.21.A1,1.SKB2.640194.21.A2,1.SKB3.640195.21.A3'
+            ',1.SKB4.640189.21.A4,1.SKB5.640181.21.A5,1.SKB6.640176.21.A6,'
+            '1.SKB7.640196.21.A7,1.SKB8.640193.21.A8,1.SKB9.640200.21.A9,'
+            '1.SKD1.640179.21.A10,1.SKD2.640178.21.A11,'
+            '1.SKD3.640198.21.A12\n'
+            'B,1.SKB1.640202.21.B1,1.SKB2.640194.21.B2,1.SKB3.640195.21.B3'
+            ',1.SKB4.640189.21.B4,1.SKB5.640181.21.B5,1.SKB6.640176.21.B6,'
+            '1.SKB7.640196.21.B7,1.SKB8.640193.21.B8,1.SKB9.640200.21.B9,'
+            '1.SKD1.640179.21.B10,1.SKD2.640178.21.B11,'
+            '1.SKD3.640198.21.B12\n'
+            'C,1.SKB1.640202.21.C1,1.SKB2.640194.21.C2,1.SKB3.640195.21.C3'
+            ',1.SKB4.640189.21.C4,1.SKB5.640181.21.C5,1.SKB6.640176.21.C6,'
+            '1.SKB7.640196.21.C7,1.SKB8.640193.21.C8,1.SKB9.640200.21.C9,'
+            '1.SKD1.640179.21.C10,1.SKD2.640178.21.C11,'
+            '1.SKD3.640198.21.C12\n'
+            'D,1.SKB1.640202.21.D1,1.SKB2.640194.21.D2,1.SKB3.640195.21.D3'
+            ',1.SKB4.640189.21.D4,1.SKB5.640181.21.D5,1.SKB6.640176.21.D6,'
+            '1.SKB7.640196.21.D7,1.SKB8.640193.21.D8,1.SKB9.640200.21.D9,'
+            '1.SKD1.640179.21.D10,1.SKD2.640178.21.D11,'
+            '1.SKD3.640198.21.D12\n'
+            'E,1.SKB1.640202.21.E1,1.SKB2.640194.21.E2,1.SKB3.640195.21.E3'
+            ',1.SKB4.640189.21.E4,1.SKB5.640181.21.E5,1.SKB6.640176.21.E6,'
+            '1.SKB7.640196.21.E7,1.SKB8.640193.21.E8,1.SKB9.640200.21.E9,'
+            '1.SKD1.640179.21.E10,1.SKD2.640178.21.E11,'
+            '1.SKD3.640198.21.E12\n'
+            'F,1.SKB1.640202.21.F1,1.SKB2.640194.21.F2,1.SKB3.640195.21.F3'
+            ',1.SKB4.640189.21.F4,1.SKB5.640181.21.F5,1.SKB6.640176.21.F6,'
+            '1.SKB7.640196.21.F7,1.SKB8.640193.21.F8,1.SKB9.640200.21.F9,'
+            '1.SKD1.640179.21.F10,1.SKD2.640178.21.F11,'
+            '1.SKD3.640198.21.F12\n'
+            'G,vibrio.positive.control.21.G1,vibrio.positive.control.21.G2,'
+            'vibrio.positive.control.21.G3,vibrio.positive.control.21.G4,'
+            'vibrio.positive.control.21.G5,vibrio.positive.control.21.G6,'
+            'vibrio.positive.control.21.G7,vibrio.positive.control.21.G8,'
+            'vibrio.positive.control.21.G9,vibrio.positive.control.21.G10,'
+            'vibrio.positive.control.21.G11,vibrio.positive.control.21.G12\n'
+            'H,blank.21.H1,blank.21.H2,blank.21.H3,blank.21.H4,'
+            'blank.21.H5,blank.21.H6,blank.21.H7,blank.21.H8,blank.21.H9,'
+            'blank.21.H10,blank.21.H11,empty.21.H12')
+        self.assertEqual(obs, exp)
+
 
 if __name__ == '__main__':
     main()

--- a/labman/gui/handlers/study.py
+++ b/labman/gui/handlers/study.py
@@ -68,3 +68,23 @@ class StudySummaryHandler(BaseHandler):
         study_numbers = study.sample_numbers_summary
         self.render('study.html', study_id=study.id,
                     study_title=study.title, study_numbers=study_numbers)
+
+
+class DownloadPlateMapsHandler(BaseHandler):
+    @authenticated
+    def get(self, study_id):
+        try:
+            study = Study(int(study_id))
+        except LabmanUnknownIdError:
+            raise HTTPError(404, reason="Study %s doesn't exist" % study_id)
+
+        text = study.generate_sample_plate_maps()
+        filename = 'PlateMaps_%s.csv' % study_id
+
+        self.set_header('Content-Type', 'text/csv')
+        self.set_header('Expires', '0')
+        self.set_header('Cache-Control', 'no-cache')
+        self.set_header('Content-Disposition',
+                        'attachment; filename=%s' % filename)
+        self.write(text)
+        self.finish()

--- a/labman/gui/templates/study.html
+++ b/labman/gui/templates/study.html
@@ -8,6 +8,7 @@
 {% block content %}
 
 <label><h3>Summary of study "{{study_title}}" (ID: {{study_id}})</h3></label>
+<a href='/study/{{study_id}}/plate_maps' class='btn btn-success'><span class='glyphicon glyphicon-download'></span> Download plate maps</a>
 
 <!-- Summary div -->
 <div>

--- a/labman/gui/test/test_study.py
+++ b/labman/gui/test/test_study.py
@@ -81,6 +81,16 @@ class TestStudyHandlers(TestHandlerBase):
         response = self.get('/study/1000/summary')
         self.assertEqual(response.code, 404)
 
+    def test_get_download_plate_maps_handler(self):
+        response = self.get('/study/1/plate_maps')
+        self.assertEqual(response.code, 200)
+        self.assertNotEqual(response.body, '')
+        self.assertTrue(response.body.startswith(
+            b'Plate "Test plate 1" (ID: 21)\n'))
+
+        response = self.get('/study/1000/plate_maps')
+        self.assertEqual(response.code, 404)
+
 
 if __name__ == '__main__':
     main()

--- a/labman/gui/webserver.py
+++ b/labman/gui/webserver.py
@@ -22,7 +22,7 @@ from labman.gui.handlers.pool import (
     PoolListHandler, PoolHandler, PoolListingHandler)
 from labman.gui.handlers.study import (
     StudyListHandler, StudyHandler, StudySamplesHandler, StudyListingHandler,
-    StudySummaryHandler)
+    StudySummaryHandler, DownloadPlateMapsHandler)
 from labman.gui.handlers.sequence import (
     SequenceRunListingHandler, SequenceRunListHandler)
 from labman.gui.handlers.sample import (
@@ -68,6 +68,7 @@ class Application(tornado.web.Application):
                     (r"/study/(.*)/", StudyHandler),
                     (r"/studies$", StudyListingHandler),
                     (r"/study/([0-9]+)/summary", StudySummaryHandler),
+                    (r"/study/([0-9]+)/plate_maps", DownloadPlateMapsHandler),
                     # Sample handlers
                     (r"/sample/control", ControlSamplesHandler),
                     (r"/sample/manage_controls", ManageControlsHandler)]


### PR DESCRIPTION
Fixes #190

I first implemented it using a function on the plate object, but after a test with a study with 200 plates I noticed it was a bit slow (see below) so I change the implementation to return all the information at once, although the code is a bit more complex. I've added comments that explain what I'm doing on the code so it is easier to maintain. As seen below, the current implementation is fast even with a study with 200 plates. Also below, a GIF with the changes in the GUI.

```python
In [1]: from labman.db.study import Study

In [2]: def f1(sid):
   ...:     study = Study(sid)
   ...:     res = [p.get_plate_map() for p in study.sample_plates]
   ...:     return '\n\n'.join(res)
   ...: 
   ...: def f2(sid):
   ...:     return Study(sid).generate_sample_plate_maps()
   ...: 

In [3]: %timeit t = f1(1)
12 s ± 330 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

In [4]: %timeit t = f2(1)
519 ms ± 8.84 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```

![platemaps](https://user-images.githubusercontent.com/2501478/36121024-d63bed76-0ff9-11e8-9aa2-67fb1136dde4.gif)
