### PR TITLE
ENH: Add a heatmap display for the quantification step

### DIFF
--- a/labman/gui/handlers/process_handlers/quantification_process.py
+++ b/labman/gui/handlers/process_handlers/quantification_process.py
@@ -15,7 +15,8 @@ from labman.gui.handlers.base import BaseHandler
 from labman.db.plate import Plate
 from labman.db.process import QuantificationProcess
 from labman.db.composition import (LibraryPrepShotgunComposition,
-                                   LibraryPrep16SComposition)
+                                   LibraryPrep16SComposition, GDNAComposition,
+                                   CompressedGDNAComposition)
 
 
 class QuantificationProcessParseHandler(BaseHandler):
@@ -55,21 +56,21 @@ class QuantificationProcessParseHandler(BaseHandler):
 
                     # cache the sample compositions to avoid extra intermediate
                     # queries
-                    if isinstance(comp, LibraryPrep16SComposition):
+                    if isinstance(comp, (LibraryPrep16SComposition,
+                                  GDNAComposition)):
                         smp = comp.gdna_composition.sample_composition
-
-                        blanks[i][j] = smp.sample_composition_type == 'blank'
-                        names[i][j] = smp.sample_id
                     elif isinstance(comp, LibraryPrepShotgunComposition):
                         smp = comp.normalized_gdna_composition\
                             .compressed_gdna_composition.gdna_composition\
                             .sample_composition
-
-                        blanks[i][j] = smp.sample_composition_type == 'blank'
-                        names[i][j] = smp.sample_id
+                    elif isinstance(comp, CompressedGDNAComposition):
+                        smp = comp.gdna_composition.sample_composition
                     else:
                         raise ValueError('This composition type is not '
                                          'supported')
+
+                    blanks[i][j] = smp.sample_composition_type == 'blank'
+                    names[i][j] = smp.sample_id
 
             plates.append({'plate_name': plate.external_id,
                            'plate_id': plate_id,

--- a/labman/gui/handlers/process_handlers/quantification_process.py
+++ b/labman/gui/handlers/process_handlers/quantification_process.py
@@ -56,15 +56,15 @@ class QuantificationProcessParseHandler(BaseHandler):
 
                     # cache the sample compositions to avoid extra intermediate
                     # queries
-                    if isinstance(comp, (LibraryPrep16SComposition,
-                                  GDNAComposition)):
+                    if isinstance(comp, GDNAComposition):
+                        smp = comp.sample_composition
+                    elif isinstance(comp, (CompressedGDNAComposition,
+                                           LibraryPrep16SComposition)):
                         smp = comp.gdna_composition.sample_composition
                     elif isinstance(comp, LibraryPrepShotgunComposition):
                         smp = comp.normalized_gdna_composition\
                             .compressed_gdna_composition.gdna_composition\
                             .sample_composition
-                    elif isinstance(comp, CompressedGDNAComposition):
-                        smp = comp.gdna_composition.sample_composition
                     else:
                         raise ValueError('This composition type is not '
                                          'supported')

--- a/labman/gui/handlers/process_handlers/quantification_process.py
+++ b/labman/gui/handlers/process_handlers/quantification_process.py
@@ -73,7 +73,8 @@ class QuantificationProcessParseHandler(BaseHandler):
                            'plate_id': plate_id,
                            'concentrations': concentrations.tolist(),
                            'names': names.tolist(),
-                           'blanks': blanks.tolist()
+                           'blanks': blanks.tolist(),
+                           'type': plate.process._process_type
                            })
 
         self.render('quantification.html', plates=plates)

--- a/labman/gui/handlers/process_handlers/quantification_process.py
+++ b/labman/gui/handlers/process_handlers/quantification_process.py
@@ -43,6 +43,8 @@ class QuantificationProcessParseHandler(BaseHandler):
             names = np.empty_like(plate.layout, dtype='object')
             blanks = np.zeros_like(plate.layout, dtype=bool)
 
+            # fetch the sample names and whether or not the samples are blanks
+            # by default these are set to be None and False.
             for i, full_row in enumerate(plate.layout):
                 for j, well in enumerate(full_row):
 

--- a/labman/gui/static/js/labman.js
+++ b/labman/gui/static/js/labman.js
@@ -286,10 +286,15 @@ function safeArrayDelete(array, elem) {
  * @param {Float} defaultClipping A number representing the default clipping
  * value for the heatmap. Depends on the processing stage and the type of
  * data being processed.
+ * @param {String} colormap Optional colormap name for the heatmap, if not
+ * provided then "YlGnBu" is used. For more information see:
+ * https://matplotlib.org/users/colormaps.html
  *
  */
 function createHeatmap(plateId, concentrations, blanks, names,
-                       defaultClipping) {
+                       defaultClipping, colormap) {
+  colormap = colormap === undefined ? 'YlGnBu' : colormap;
+
   var $container = $('#pool-results-' + plateId);
   var $heatmap = $('<div id="heatmap-' + plateId + '"></div>');
   var $histogram = $('<div id="histogram-' + plateId + '"></div>');
@@ -376,7 +381,7 @@ function createHeatmap(plateId, concentrations, blanks, names,
       text: hoverlabels,
       hoverinfo: 'text',
       type: 'heatmap',
-      colorscale: 'YlGnBu',
+      colorscale: colormap,
       colorbar:{
         title: 'DNA Concentration',
         titleside:'top',

--- a/labman/gui/templates/quantification.html
+++ b/labman/gui/templates/quantification.html
@@ -1,18 +1,14 @@
 {% extends sitebase.html %}
 
 {% block head %}
-<link rel="stylesheet" href="/static/vendor/css/slick-default-theme.css" type="text/css"/>
-<link rel="stylesheet" href="/static/vendor/css/slick.grid.css" type="text/css"/>
+{% import json %}
 
-<script src="/static/vendor/js/jquery.event.drag-2.3.0.js" type="text/javascript"></script>
-<script src="/static/vendor/js/slick.core.js" type="text/javascript"></script>
-<script src="/static/vendor/js/slick.grid.js" type="text/javascript"></script>
-<script src="/static/vendor/js/slick.editors.js" type="text/javascript"></script>
+<script src="/static/vendor/js/plotly-1.33.1.min.js"></script>
 
 
 <script type='text/javascript'>
   function confirmQuantification() {
-    var plates = {% raw plates %};
+    var plates = {% raw json.dumps(plates) %};
     $.post("/process/quantify", {'plates-info': JSON.stringify(plates)}, function(data) {
       bootstrapAlert('Information saved', 'success');
       disableAll();
@@ -29,32 +25,15 @@
   };
 
   $(document).ready(function(){
-    var plates = {% raw plates %};
+    var plates = {% raw json.dumps(plates) %};
 
-    var sgOptions = {editable: false,
-                     enableAddRow: false,
-                     enableCellNavigation: true,
-                     asyncEditorLoading: false,
-                     enableColumnReorder: false,
-                     autoEdit: false};
     for (var plateInfo of plates) {
       var concentrations = plateInfo['concentrations'];
-      var sgCols = [{id: 'selector', name: '', field: 'header', width: 30}]
-      for (var i = 0; i < concentrations[0].length; i++) {
-        sgCols.push({id: i, name: i+1, field: i});
-      }
-      var data = [];
-      var rowId = 'A';
-      for (var i = 0; i < concentrations.length; i++) {
-        var d = (data[i] = {});
-        d["header"] = rowId;
-        for (var j = 0; j < concentrations[i].length; j++) {
-          d[j] = concentrations[i][j];
-        }
-        rowId = getNextRowId(rowId);
-      }
+      var names = plateInfo['names'];
+      var blanks = plateInfo['blanks'];
 
-      grid = new Slick.Grid($('#grid-div-' + plateInfo['plate_id']), data, sgCols, sgOptions);
+      createHeatmap(plateInfo['plate_id'], concentrations, blanks, names, 30,
+                    'Viridis');
     }
   });
 </script>
@@ -67,7 +46,7 @@
 {% for plate_info in plates %}
 <div list-group-item>
   <h4>{{plate_info['plate_name']}}</h4>
-  <div id='grid-div-{{plate_info['plate_id']}}' style="width:100%;height:250px"></div>
+  <div id='pool-results-{{plate_info['plate_id']}}'></div>
 <div>
 {% end %}
 

--- a/labman/gui/templates/quantification.html
+++ b/labman/gui/templates/quantification.html
@@ -38,6 +38,9 @@
     else if (plateType == 'shotgun library prep') {
       return 30;
     }
+    else if (plateType == 'gDNA' || plateType == 'compressed gDNA') {
+      return 20;
+    }
 
     // should never get here but if it does, then the range is permissive
     return 10000;

--- a/labman/gui/templates/quantification.html
+++ b/labman/gui/templates/quantification.html
@@ -24,16 +24,36 @@
     }
   };
 
+  /**
+   * Determine an appropriate clipping value for the heatmap's maximum value.
+   *
+   * @param {Float} plateType String describing the plate type.
+   * @returns A maximum expected value for the colorscale of a heatmap.
+   *
+   */
+  function clippingForPlateType(plateType) {
+    if (plateType == '16S library prep') {
+      return 100;
+    }
+    else if (plateType == 'shotgun library prep') {
+      return 30;
+    }
+
+    // should never get here but if it does, then the range is permissive
+    return 10000;
+  }
+
   $(document).ready(function(){
     var plates = {% raw json.dumps(plates) %};
 
     for (var plateInfo of plates) {
-      var concentrations = plateInfo['concentrations'];
-      var names = plateInfo['names'];
-      var blanks = plateInfo['blanks'];
+      var defaultClipping = clippingForPlateType(plateInfo.type);
+      var concentrations = plateInfo.concentrations;
+      var names = plateInfo.names;
+      var blanks = plateInfo.blanks;
 
-      createHeatmap(plateInfo['plate_id'], concentrations, blanks, names, 30,
-                    'Viridis');
+      createHeatmap(plateInfo.plate_id, concentrations, blanks, names,
+                    defaultClipping, 'Viridis');
     }
   });
 </script>


### PR DESCRIPTION
The quantification step ditches the grid view and now reuses the display
element for the pooling step:

![quantification](https://user-images.githubusercontent.com/375307/36276199-2599baf2-125b-11e8-80b7-980ccd0e9b4d.gif)

This PR also parametrizes the colormap to fit the step, by recommendation of @tanaes Viridis is used for quantification.

Related to #195