### PR TITLE
ENH: Style odd and even rows to improve readability

### DIFF
--- a/labman/gui/static/css/labman.css
+++ b/labman/gui/static/css/labman.css
@@ -179,3 +179,16 @@ kbd.key {
     /* disable "hovering" events and other mouse interaction events */
     pointer-events: none;
 }
+
+/*
+ *
+ * Zebrafiy the rows of all the datatables in the project
+ *
+ */
+table.dataTable tr.odd {
+  background-color: #ededed;
+}
+
+table.dataTable tr.even {
+  background-color: white;
+}


### PR DESCRIPTION
Adds some CSS to change the styling of the rows in a DataTables element. I noticed it was a bit confusing to try and click the add button on the right while trying to match a name on the left. Went from:

<img width="886" alt="screen shot 2018-02-15 at 2 49 49 pm" src="https://user-images.githubusercontent.com/375307/36277686-961b7924-125f-11e8-9641-d14666ce9a22.png">


To:

<img width="881" alt="screen shot 2018-02-15 at 2 49 25 pm" src="https://user-images.githubusercontent.com/375307/36277692-99e07802-125f-11e8-99a0-d773088ea174.png">
