### PR TITLE
WIP: Fix amplicon pooling

### DIFF
--- a/labman/db/process.py
+++ b/labman/db/process.py
@@ -1565,7 +1565,7 @@ class QuantificationProcess(Process):
     _process_type = 'quantification'
 
     @staticmethod
-    def _compute_shotgun_pico_concentration(dna_vals, size=500):
+    def _compute_pico_concentration(dna_vals, size=500):
         """Computes molar concentration of libraries from library DNA
         concentration values.
 
@@ -1787,64 +1787,29 @@ class QuantificationProcess(Process):
                 (composition_module.Composition.factory(comp_id), r_con, c_con)
                 for comp_id, r_con, c_con in TRN.execute_fetchindex()]
 
-    def compute_concentrations(self, dna_amount=240, min_val=1, max_val=15,
-                               blank_volume=2, size=500):
-        """Compute the normalized concentrations
+    def compute_concentrations(self, size=500):
+        """Compute the normalized library molarity based on pico green dna
+        concentrations estimates.
 
         Parameters
         ----------
-        dna_amount: float, optional
-            (Amplicon) Total amount of DNA, in ng. Default: 240
-        min_val: float, optional
-            (Amplicon) Minimum amount of DNA to normalize to (nM). Default: 1
-        max_val: float, optional
-            (Amplicon) Maximum value. Wells above this number will be
-            excluded (nM). Default: 15
-        blank_volume: float, optional
-            (Amplicon) Amount to pool for the blanks (nM). Default: 2.
         size: int, optional
-            (Shotgun) The average library molecule size, in bp.
+            The average library molecule size, in bp.
         """
         concentrations = self.concentrations
         layout = concentrations[0][0].container.plate.layout
 
         res = None
-        if isinstance(concentrations[0][0],
-                      composition_module.LibraryPrep16SComposition):
-            # Amplicon
-            sample_concs = np.zeros_like(layout, dtype=float)
-            is_blank = np.zeros_like(layout, dtype=bool)
-            for comp, r_conc, _ in concentrations:
-                well = comp.container
-                row = well.row - 1
-                col = well.column - 1
-                sample_concs[row][col] = r_conc
-                sc = comp.gdna_composition.sample_composition
-                is_blank[row][col] = sc.sample_composition_type == 'blank'
 
-            res = QuantificationProcess._compute_amplicon_pool_values(
-                sample_concs, dna_amount)
-            res[sample_concs < min_val] = min_val
-            # If there is any sample whose concentration is above the
-            # user-defined max_value, the decision is to not pool that sample.
-            # To not pool the sample, define it's volume to 0 and it will not
-            # get pooled.
-            res[sample_concs > max_val] = 0
-            res[is_blank] = blank_volume
-        elif isinstance(concentrations[0][0],
-                        composition_module.LibraryPrepShotgunComposition):
-            # Shotgun
-            sample_concs = np.zeros_like(layout, dtype=float)
-            for comp, r_conc, _ in concentrations:
-                well = comp.container
-                row = well.row - 1
-                col = well.column - 1
-                sample_concs[row][col] = r_conc
+        sample_concs = np.zeros_like(layout, dtype=float)
+        for comp, r_conc, _ in concentrations:
+            well = comp.container
+            row = well.row - 1
+            col = well.column - 1
+            sample_concs[row][col] = r_conc
 
-            res = QuantificationProcess._compute_shotgun_pico_concentration(
-                sample_concs, size)
-        # No need for else, because if it is not one of the above types
-        # we don't need to do anything
+        res = QuantificationProcess._compute_pico_concentration(
+            sample_concs, size)
 
         if res is not None:
             sql_args = []
@@ -1927,7 +1892,7 @@ class PoolingProcess(Process):
         return (pool_conc, total_vol)
 
     @staticmethod
-    def compute_shotgun_pooling_values_eqvol(sample_concs, total_vol=60.0):
+    def compute_pooling_values_eqvol(sample_concs, total_vol=60.0):
         """Computes molar concentration of libraries from concentration values,
         using an even volume per sample
 
@@ -1948,9 +1913,9 @@ class PoolingProcess(Process):
         return sample_vols
 
     @staticmethod
-    def compute_shotgun_pooling_values_minvol(
-            sample_concs, sample_fracs=None, floor_vol=100, floor_conc=40,
-            total_nmol=.01):
+    def compute_pooling_values_minvol(
+            sample_concs, sample_fracs=None, floor_vol=2, floor_conc=16,
+            total=240, total_each=True, vol_constant=1):
         """Computes pooling volumes for samples based on concentration
         estimates of nM concentrations (`sample_concs`), taking a minimum
         volume of samples below a threshold.
@@ -1966,7 +1931,7 @@ class PoolingProcess(Process):
         pooling.
 
         Finally, total pooling size is determined by a target nanomolar
-        quantity (`total_nmol`, default .01). For a perfect 384 sample library,
+        quantity (`total`, default .01). For a perfect 384 sample library,
         in which you had all samples at a concentration of exactly 400 nM and
         wanted a total volume of 60 uL, this would be 0.024 nmol.
 
@@ -1978,16 +1943,26 @@ class PoolingProcess(Process):
         Parameters
         ----------
         sample_concs: 2D array of float
-            nM sample concentrations
+            sample concentrations, with numerator same units as `total`.
         sample_fracs: 2D of float, optional
             fractional value for each sample (default 1/N)
         floor_vol: float, optional
-            volume (nL) at which samples below floor_conc will be pooled.
+            volume at which samples below floor_conc will be pooled.
             Default: 100
         floor_conc: float, optional
-            minimum value (nM) for pooling at real estimated value. Default: 40
-        total_nmol : float, optional
-            total number of nM to have in pool. Default: 0.01
+            minimum value for pooling at real estimated value. Default: 40
+        total : float, optional
+            total quantity (numerator) for pool. Unitless, but could represent
+            for example ng or nmol. Default: 240
+        total_each : bool, optional
+            whether `total` refers to the quantity pooled *per sample*
+            (default; True) or to the total quantity of the pool.
+        vol_constant : float, optional
+            conversion factor between `sample_concs` demoninator and output
+            pooling volume units. E.g. if pooling ng/µL concentrations and
+            producing µL pool volumes, `vol_constant` = 1. If pooling nM
+            concentrations and producing nL pool volumes, `vol_constant` =
+            10**-9. Default: 1
 
         Returns
         -------
@@ -1995,73 +1970,19 @@ class PoolingProcess(Process):
             the volumes in nL per each sample pooled
         """
         if sample_fracs is None:
-            sample_fracs = np.ones(sample_concs.shape) / sample_concs.size
+            sample_fracs = np.ones(sample_concs.shape)
+
+        if not total_each:
+            sample_fracs = sample_fracs / sample_concs.size
 
         # calculate volumetric fractions including floor val
-        sample_vols = (total_nmol * sample_fracs) / sample_concs
-        # convert L to nL
-        sample_vols *= 10**9
+        sample_vols = (total * sample_fracs) / sample_concs
+        # convert volume from concentration units to pooling units
+        sample_vols *= vol_constant
         # drop volumes for samples below floor concentration to floor_vol
         sample_vols[sample_concs < floor_conc] = floor_vol
         return sample_vols
 
-    @staticmethod
-    def compute_shotgun_pooling_values_floor(
-            sample_concs, sample_fracs=None, min_conc=10, floor_conc=50,
-            total_nmol=.01):
-        """Computes pooling volumes for samples based on concentration
-        estimates of nM concentrations (`sample_concs`).
-
-        Reads in concentration values in nM. Samples must be above a minimum
-        concentration threshold (`min_conc`, default 10 nM) to be included.
-        Samples above this threshold but below a given floor concentration
-        (`floor_conc`, default 50 nM) will be pooled as if they were at the
-        floor concentration, to avoid overdiluting the pool.
-
-        Samples can be assigned a target molar fraction in the pool by passing
-        a np.array (`sample_fracs`, same shape as `sample_concs`) with
-        fractional values per sample. By default, will aim for equal molar
-        pooling.
-
-        Finally, total pooling size is determined by a target nanomolar
-        quantity (`total_nmol`, default .01). For a perfect 384 sample library,
-        in which you had all samples at a concentration of exactly 400 nM and
-        wanted a total volume of 60 uL, this would be 0.024 nmol.
-
-        Parameters
-        ----------
-        sample_concs: 2D array of float
-            nM calculated by compute_qpcr_concentration
-        sample_fracs: 2D of float, optional
-            fractional value for each sample (default 1/N)
-        min_conc: float, optional
-            minimum nM concentration to be included in pool. Default: 10
-        floor_conc: float, optional
-            minimum value for pooling for samples above min_conc. Default: 50
-        total_nmol : float, optional
-            total number of nM to have in pool. Default 0.01
-
-        Returns
-        -------
-        sample_vols: np.array of floats
-            the volumes in nL per each sample pooled
-        """
-        if sample_fracs is None:
-            sample_fracs = np.ones(sample_concs.shape) / sample_concs.size
-
-        # get samples above threshold
-        sample_fracs_pass = sample_fracs.copy()
-        sample_fracs_pass[sample_concs <= min_conc] = 0
-        # renormalize to exclude lost samples
-        sample_fracs_pass *= 1/sample_fracs_pass.sum()
-        # floor concentration value
-        sample_concs_floor = sample_concs.copy()
-        sample_concs_floor[sample_concs < floor_conc] = floor_conc
-        # calculate volumetric fractions including floor val
-        sample_vols = (total_nmol * sample_fracs_pass) / sample_concs_floor
-        # convert L to nL
-        sample_vols *= 10**9
-        return sample_vols
 
     @classmethod
     def create(cls, user, quantification_process, pool_name, volume,

--- a/labman/db/process.py
+++ b/labman/db/process.py
@@ -1892,7 +1892,7 @@ class PoolingProcess(Process):
         return (pool_conc, total_vol)
 
     @staticmethod
-    def compute_pooling_values_eqvol(sample_concs, total_vol=60.0):
+    def compute_pooling_values_eqvol(sample_concs, total_vol=60.0, **kwargs):
         """Computes molar concentration of libraries from concentration values,
         using an even volume per sample
 
@@ -1915,7 +1915,7 @@ class PoolingProcess(Process):
     @staticmethod
     def compute_pooling_values_minvol(
             sample_concs, sample_fracs=None, floor_vol=2, floor_conc=16,
-            total=240, total_each=True, vol_constant=1):
+            total=240, total_each=True, vol_constant=1, **kwargs):
         """Computes pooling volumes for samples based on concentration
         estimates of nM concentrations (`sample_concs`), taking a minimum
         volume of samples below a threshold.

--- a/labman/db/support_files/populate_test_db.sql
+++ b/labman/db/support_files/populate_test_db.sql
@@ -569,8 +569,9 @@ BEGIN
         RETURNING process_id INTO p_pool_process_id;
 
     INSERT INTO qiita.pooling_process (process_id, quantification_process_id, robot_id, destination, pooling_function_data)
-        VALUES (p_pool_process_id, pg_quant_subprocess_id, proc_robot_id, 1, '{"function": "amplicon", "parameters": {"dna-amount-": 240, "min-val-": 1, "max-val-": 15, "blank-val-": 2}}'::json)
+        VALUES (p_pool_process_id, pg_quant_subprocess_id, proc_robot_id, 1, '{"function": "amplicon", "parameters": {"total-": 240, "floor-vol-": 2, "floor-conc-": 16}}'::json)
         RETURNING pooling_process_id INTO p_pool_subprocess_id;
+
 
     ----------------------------------------
     ------ SEQUENCING POOLING PROCESS ------

--- a/labman/db/support_files/populate_test_db.sql
+++ b/labman/db/support_files/populate_test_db.sql
@@ -659,7 +659,7 @@ BEGIN
 
     -- Quantify plate pools
     INSERT INTO qiita.concentration_calculation (quantitated_composition_id, upstream_process_id, raw_concentration)
-        VALUES (p_pool_composition_id, ppg_quant_subprocess_id, 1.5);
+        VALUES (p_pool_composition_id, ppg_quant_subprocess_id, 25);
 
     -- Pool sequencing run
     INSERT INTO qiita.container (container_type_id, latest_upstream_process_id, remaining_volume)

--- a/labman/db/tests/test_process.py
+++ b/labman/db/tests/test_process.py
@@ -628,11 +628,11 @@ class TestNormalizationProcess(LabmanTestCase):
 
 
 class TestQuantificationProcess(LabmanTestCase):
-    def test_compute_shotgun_pico_concentration(self):
+    def test_compute_pico_concentration(self):
         dna_vals = np.array([[10.14, 7.89, 7.9, 15.48],
                              [7.86, 8.07, 8.16, 9.64],
                              [12.29, 7.64, 7.32, 13.74]])
-        obs = QuantificationProcess._compute_shotgun_pico_concentration(
+        obs = QuantificationProcess._compute_pico_concentration(
             dna_vals, size=400)
         exp = np.array([[38.4090909, 29.8863636, 29.9242424, 58.6363636],
                         [29.7727273, 30.5681818, 30.9090909, 36.5151515],
@@ -926,32 +926,34 @@ class TestLibraryPrepShotgunProcess(LabmanTestCase):
 
 
 class TestPoolingProcess(LabmanTestCase):
-    def test_compute_shotgun_pooling_values_eqvol(self):
+    def test_compute_pooling_values_eqvol(self):
         qpcr_conc = np.array(
             [[98.14626462, 487.8121413, 484.3480866, 2.183406934],
              [498.3536649, 429.0839787, 402.4270321, 140.1601735],
              [21.20533391, 582.9456031, 732.2655041, 7.545145988]])
-        obs_sample_vols = PoolingProcess.compute_shotgun_pooling_values_eqvol(
+        obs_sample_vols = PoolingProcess.compute_pooling_values_eqvol(
             qpcr_conc, total_vol=60.0)
         exp_sample_vols = np.zeros([3, 4]) + 5000
         npt.assert_allclose(obs_sample_vols, exp_sample_vols)
 
-        obs_sample_vols = PoolingProcess.compute_shotgun_pooling_values_eqvol(
+        obs_sample_vols = PoolingProcess.compute_pooling_values_eqvol(
             qpcr_conc, total_vol=60)
         npt.assert_allclose(obs_sample_vols, exp_sample_vols)
 
-    def test_compute_shotgun_pooling_values_minvol(self):
+    def test_compute_pooling_values_minvol(self):
         sample_concs = np.array([[1, 12, 400], [200, 40, 1]])
         exp_vols = np.array([[100, 100, 4166.6666666666],
                              [8333.33333333333, 41666.666666666, 100]])
-        obs_vols = PoolingProcess.compute_shotgun_pooling_values_minvol(
-            sample_concs)
+        obs_vols = PoolingProcess.compute_pooling_values_minvol(
+            sample_concs, total=.01, floor_vol=100, floor_conc=40,
+            total_each=False, vol_constant=10**9)
         npt.assert_allclose(exp_vols, obs_vols)
 
-    def test_compute_shotgun_pooling_values_floor(self):
-        sample_concs = np.array([[1, 12, 400], [200, 40, 1]])
-        exp_vols = np.array([[0, 50000, 6250], [12500, 50000, 0]])
-        obs_vols = PoolingProcess.compute_shotgun_pooling_values_floor(
+    def test_compute_pooling_values_minvol_amplicon(self):
+        sample_concs = np.array([[1, 12, 40], [200, 40, 1]])
+        exp_vols = np.array([[2, 2, 6],
+                             [1.2, 6, 2]])
+        obs_vols = PoolingProcess.compute_pooling_values_minvol(
             sample_concs)
         npt.assert_allclose(exp_vols, obs_vols)
 

--- a/labman/gui/handlers/process_handlers/pooling_process.py
+++ b/labman/gui/handlers/process_handlers/pooling_process.py
@@ -81,6 +81,8 @@ HTML_POOL_PARAMS_16S = {
                'step': '1'},
               {'prefix': 'robot-'}, {'prefix': 'dest-tube-'}]}
 
+HTML_POOL_PARAMS = {'16S library prep': HTML_POOL_PARAMS_16S,
+                    'shotgun library prep': HTML_POOL_PARAMS_SHOTGUN}
 
 # quick function to create 2D representation of well-associated numbers
 def make_2D_arrays(plate, quant_process):
@@ -157,6 +159,8 @@ class BasePoolHandler(BaseHandler):
         func_info = POOL_FUNCS[func_name]
         function = func_info['function']
 
+        print('foo')
+
         plate = Plate(plate_id)
         quant_process = plate.quantification_process
 
@@ -197,6 +201,8 @@ class BasePoolHandler(BaseHandler):
         output['pool_blanks'] = comp_blanks.tolist()
         output['plate_names'] = plate_names.tolist()
         output['plate_id'] = plate_id
+        output['destination'] = params['destination']
+        output['robot'] = params['robot']
 
         return output
 
@@ -286,11 +292,6 @@ class LibraryPoolProcessHandler(BasePoolHandler):
 
         robots = Equipment.list_equipment('EpMotion') + \
                     Equipment.list_equipment('echo')
-
-        if plate_type == '16S library prep':
-            HTML_POOL_PARAMS = HTML_POOL_PARAMS_16S
-        else:
-            HTML_POOL_PARAMS = HTML_POOL_PARAMS_SHOTGUN
 
         self.render('library_pooling.html', plate_ids=plate_ids,
                     robots=robots, pool_params=HTML_POOL_PARAMS,

--- a/labman/gui/handlers/process_handlers/pooling_process.py
+++ b/labman/gui/handlers/process_handlers/pooling_process.py
@@ -183,7 +183,7 @@ class BasePoolHandler(BaseHandler):
         if plate_type == '16S library prep':
             params['total_each'] = True
             params['vol_constant'] = 1
-            pool_vals = function(comp_concs, **params)
+            pool_vals = function(raw_concs, **params)
         if plate_type == 'shotgun library prep':
             params['total_each'] = False
             params['vol_constant'] = 10**9

--- a/labman/gui/handlers/process_handlers/test/test_pooling_process.py
+++ b/labman/gui/handlers/process_handlers/test/test_pooling_process.py
@@ -83,23 +83,25 @@ class TestPoolingProcessHandlers(TestHandlerBase):
         self.assertEqual(response.code, 404)
 
     def test_post_library_pool_process_handler(self):
-        # Amplicon test
+
+        # Shotgun test
         data = {'plates-info': json_encode([{
-            'plate-id': 23, 'pool-func': 'min',
-            'plate-type': '16S library prep',
-            'total-23': 240, 'floor-vol-23': 2, 'floor-conc-23': 16,
-            'robot-23': 10, 'dest-tube-23': 1}])}
+            'plate-id': 26, 'pool-func': 'equal',
+            'plate-type': 'shotgun library prep', 'volume-26': 200,
+            'lib-size-26': 500, 'robot-26': 10, 'dest-tube-26': 1}])}
+
         response = self.post('/process/poollibraries', data)
         self.assertEqual(response.code, 200)
         obs = json_decode(response.body)
         self.assertEqual(len(obs), 1)
         self.assertCountEqual(obs[0], ['plate-id', 'process-id'])
 
-        # Shotgun test
+        # Amplicon test
         data = {'plates-info': json_encode([{
-            'plate-id': 26, 'pool-func': 'equal',
-            'plate-type': 'shotgun library prep', 'volume-26': 200,
-            'lib-size-26': 500, 'robot-23': 10, 'dest-tube-23': 1}])}
+            'plate-id': 23, 'pool-func': 'min',
+            'plate-type': '16S library prep',
+            'total-23': 240, 'floor-vol-23': 2, 'floor-conc-23': 16,
+            'lib-size-23': 500, 'robot-23': 10, 'dest-tube-23': 1}])}
         response = self.post('/process/poollibraries', data)
         self.assertEqual(response.code, 200)
         obs = json_decode(response.body)
@@ -128,12 +130,12 @@ class TestPoolingProcessHandlers(TestHandlerBase):
             'plate-id': 23, 'pool-func': 'min',
             'plate-type': '16S library prep',
             'total-23': 240, 'floor-vol-23': 2, 'floor-conc-23': 16,
-            'robot-23': 10, 'dest-tube-23': 1})}
+            'lib-size-23': 500, 'robot-23': 10, 'dest-tube-23': 1})}
         response = self.post('/process/compute_pool', data)
         self.assertEqual(response.code, 200)
         self.assertCountEqual(json_decode(response.body),
                               ['plate_id', 'pool_vals', 'pool_blanks',
-                               'plate_names'])
+                               'plate_names', 'destination', 'robot'])
 
         data = {'plate-info': json_encode({
             'plate-id': 23, 'pool-func': 'min',

--- a/labman/gui/templates/library_pooling.html
+++ b/labman/gui/templates/library_pooling.html
@@ -34,7 +34,7 @@
           $('#pool-func-' + plateId).val(funcData['function']);
           // Build the function FROM
           $('#pool-func-' + plateId).trigger($.Event('change'));
-          $.each(poolParams[funcData['function']], function(idx, paramElem) {
+          $.each(poolParams[plateType][funcData['function']], function(idx, paramElem) {
             parameterName = paramElem['prefix'] + plateId;
             $('#' + parameterName).val(funcData['parameters'][paramElem['prefix']]);
 
@@ -94,7 +94,7 @@
     poolFunc = $(elem).find('select').val();
 
     var plateInfo = {'plate-id': plateId, 'pool-func': poolFunc, 'plate-type': plateType};
-    $.each(poolParams[poolFunc], function(idx, paramElem) {
+    $.each(poolParams[plateType][poolFunc], function(idx, paramElem) {
       parameterName = paramElem['prefix'] + plateId;
       plateInfo[parameterName] = $('#' + parameterName).val();
     });
@@ -175,7 +175,7 @@
           $('#compute-pool-btn').prop('disabled', true);
           disabled = true;
         } else {
-          $.each(poolParams[poolFunc], function(idx, paramElem) {
+          $.each(poolParams[plateType][poolFunc], function(idx, paramElem) {
             var isEmpty = $('#' + paramElem['prefix'] + plateId).val() === '';
             $('#compute-pool-btn').prop('disabled', isEmpty || isPoolBtnDisabled);
             disabled = disabled || isEmpty;
@@ -203,8 +203,9 @@
   function poolFuncCallback() {
     var plateId = $(this).attr('plate-id');
     var $target = $('#pool-params-div-' + plateId);
+    var plateType = $('#plate-type-select').val();
     $target.empty();
-    $.each(poolParams[$(this).val()], function(idx, elem) {
+    $.each(poolParams[plateType][$(this).val()], function(idx, elem) {
       if (elem['prefix'] === 'robot-') {
             createSelectDOM($('#pool-params-div-' + plateId), plateId, paramOnChangeCallback, 'Pooling robot', {% raw robots %}, elem['prefix'], 'Select robot...');
           } else if (elem['prefix'] === 'dest-tube-') {

--- a/labman/gui/templates/library_pooling.html
+++ b/labman/gui/templates/library_pooling.html
@@ -21,7 +21,7 @@
       disableAll();
       bootstrapAlert('Loading data...', 'info');
       var funcData = {% raw pool_func_data %};
-      var plateType = funcData['function'] === 'amplicon' ? '16S library prep' : 'shotgun library prep';
+      var plateType = {% raw plate_type %};
       var defaultClipping = clippingForPlateType(plateType);
 
       $('#plate-type-select').val(plateType);
@@ -91,13 +91,9 @@
     var plateType = $('#plate-type-select').val();
     var parameterName, poolFunc;
 
-    if (plateType === '16S library prep') {
-      poolFunc = 'amplicon';
-    } else {
-      poolFunc = $(elem).find('select').val();
-    }
+    poolFunc = $(elem).find('select').val();
 
-    var plateInfo = {'plate-id': plateId, 'pool-func': poolFunc};
+    var plateInfo = {'plate-id': plateId, 'pool-func': poolFunc, 'plate-type': plateType};
     $.each(poolParams[poolFunc], function(idx, paramElem) {
       parameterName = paramElem['prefix'] + plateId;
       plateInfo[parameterName] = $('#' + parameterName).val();
@@ -172,31 +168,20 @@
       var isPoolBtnDisabled = $('#compute-pool-btn').prop('disabled');
       var disabled = !isPoolBtnDisabled;
       var plateType = $('#plate-type-select').val();
-      if (plateType === '16S library prep') {
-        $.each(plates, function(idx, elem) {
-          var plateId = $(elem).attr('pm-data-plate-id');
-          $.each(poolParams['amplicon'], function(idx, paramElem) {
+      $.each(plates, function(idx, elem) {
+        var plateId = $(elem).attr('pm-data-plate-id');
+        var poolFunc = $(elem).find('select').val();
+        if (poolFunc === null) {
+          $('#compute-pool-btn').prop('disabled', true);
+          disabled = true;
+        } else {
+          $.each(poolParams[poolFunc], function(idx, paramElem) {
             var isEmpty = $('#' + paramElem['prefix'] + plateId).val() === '';
             $('#compute-pool-btn').prop('disabled', isEmpty || isPoolBtnDisabled);
             disabled = disabled || isEmpty;
           });
-        });
-      } else {
-        $.each(plates, function(idx, elem) {
-          var plateId = $(elem).attr('pm-data-plate-id');
-          var poolFunc = $(elem).find('select').val();
-          if (poolFunc === null) {
-            $('#compute-pool-btn').prop('disabled', true);
-            disabled = true;
-          } else {
-            $.each(poolParams[poolFunc], function(idx, paramElem) {
-              var isEmpty = $('#' + paramElem['prefix'] + plateId).val() === '';
-              $('#compute-pool-btn').prop('disabled', isEmpty || isPoolBtnDisabled);
-              disabled = disabled || isEmpty;
-            });
-          }
-        });
-      }
+        }
+      });
       $('#pool-btn').prop('disabled', disabled);
     }
   };
@@ -220,7 +205,13 @@
     var $target = $('#pool-params-div-' + plateId);
     $target.empty();
     $.each(poolParams[$(this).val()], function(idx, elem) {
-      createNumberInputDOM($('#pool-params-div-' + plateId), plateId, paramOnChangeCallback, elem['desc'], elem['value'], elem['prefix'], elem['step'], elem['min']);
+      if (elem['prefix'] === 'robot-') {
+            createSelectDOM($('#pool-params-div-' + plateId), plateId, paramOnChangeCallback, 'Pooling robot', {% raw robots %}, elem['prefix'], 'Select robot...');
+          } else if (elem['prefix'] === 'dest-tube-') {
+            createTextInputDOM($('#pool-params-div-' + plateId), plateId, paramOnChangeCallback, 'Destination tube', '1', elem['prefix']);
+          } else {
+            createNumberInputDOM($('#pool-params-div-' + plateId), plateId, paramOnChangeCallback, elem['desc'], elem['value'], elem['prefix'], elem['step'], elem['min']);
+          }
     });
     enableComputePoolValues();
     poolingChecks();
@@ -259,26 +250,13 @@
       $divElem.append('<div id="download-' + plateId + '" hidden><a class="btn btn-default"><span class="glyphicon glyphicon-download"></span> Download pool file</a></div>');
       var $formDiv = $("<div>").addClass('form-horizontal').appendTo($divElem);
       var plateType = $('#plate-type-select').val();
-      if (plateType === '16S library prep') {
-        // Amplicon library There is only 1 library prep function - add the parameters
-        $.each(poolParams['amplicon'], function(idx, elem) {
-          if (elem['prefix'] === 'epmotion-') {
-            createSelectDOM($formDiv, plateId, paramOnChangeCallback, 'EpMotion robot', {% raw epmotions %}, elem['prefix'], 'Select EpMotion...');
-          } else if (elem['prefix'] === 'dest-tube-') {
-            createTextInputDOM($formDiv, plateId, paramOnChangeCallback, 'EpMotion destination tube', '1', elem['prefix']);
-          } else {
-            createNumberInputDOM($formDiv, plateId, paramOnChangeCallback, elem['desc'], elem['value'], elem['prefix'], elem['step'], elem['min']);
-          }
-        });
-        enableComputePoolValues();
-      } else {
-        // Add a select for choosing the pooling function
-        var poolFuncOpts = [{'func_id': 'equal', 'external_id': 'Equal volume'},
-                            {'func_id': 'min', 'external_id': 'Minimum volume'},
-                            {'func_id': 'floor', 'external_id': 'Floor volume'}];
-        createSelectDOM($formDiv, plateId, poolFuncCallback, 'Pooling function', poolFuncOpts, 'pool-func-', 'Choose pooling function...', 'func_id');
-        $('<div>').addClass('form-horizontal').attr('id', 'pool-params-div-' + plateId).appendTo($formDiv);
-      }
+      
+      // Add a select for choosing the pooling function
+      var poolFuncOpts = [{'func_id': 'equal', 'external_id': 'Equal volume'},
+                          {'func_id': 'min', 'external_id': 'Minimum volume'}];
+      createSelectDOM($formDiv, plateId, poolFuncCallback, 'Pooling function', poolFuncOpts, 'pool-func-', 'Choose pooling function...', 'func_id');
+      $('<div>').addClass('form-horizontal').attr('id', 'pool-params-div-' + plateId).appendTo($formDiv);
+    
       // Add a space for the pooling function results
       $('<div>').addClass('form-group').appendTo($formDiv).attr('id', 'pool-results-' + plateId);
       // Add the element to the plate list


### PR DESCRIPTION
This is a first stab at fixing issue #203. 

I've modified the underlying functional logic and HTML code to enable sensible application of minvol and eqvol pooling to both amplicon and shotgun library plates. This also involves passing per-library-type defaults and making some different choices when calculating pooling (for example, amplicon is pooling by raw ng/uL concentrations and shotgun by calculated nM concentrations)

Still to do:

- [ ] Add blank-specific behavior; for example, allow user to pool only N blanks at X volume.
- [ ] update heatmap display so that it's got the right titles (e.g. it's displaying volumes, not concentrations)
- [ ] improve interface -- not optimal allocation of space to e.g. parameters entry boxes vs descriptions

Some specific questions for review:
1. There are parameter values that are stored (e.g. robot used and destination) but that aren't used by the pooling calculation itself. Are those being handled the correct way? E.g. labman/gui/handlers/process_handlers/pooling_process.py L30
2. some of these parameters might be more appropriately specified *per pool* rather than *per plate*