### PR TITLE
ENH: Improve grid space usage

### DIFF
--- a/labman/gui/static/css/labman.css
+++ b/labman/gui/static/css/labman.css
@@ -180,6 +180,11 @@ kbd.key {
     pointer-events: none;
 }
 
+/* make the header text be fully visible */
+.full-height-header {
+  height: 100% !important;
+}
+
 /*
  *
  * Zebrafiy the rows of all the datatables in the project

--- a/labman/gui/static/js/plateViewer.js
+++ b/labman/gui/static/js/plateViewer.js
@@ -112,25 +112,38 @@ PlateViewer.prototype.initialize = function (rows, cols) {
                    enableCellNavigation: true,
                    asyncEditorLoading: false,
                    enableColumnReorder: false,
-                   autoEdit: true};
+                   autoEdit: true,
+                   resizable: true};
 
   var frozenColumnOptions = {editable: false,
                              enableCellNavigation: false,
                              enableColumnReorder: false,
                              autoEdit: false};
 
-  // use the slick-header-column but with mouse events disabled, see labman.css
+  // Use the slick-header-column but with mouse events disabled
+  // Without the &nbsp; the header will be smaller than for the main grid
   var frozenColumn = [{id: 'selector',
-                       name: '', field: 'header',
+                       name: '&nbsp;',
+                       field: 'header',
                        width: 22,
-                       cssClass: 'slick-header-column'}];
+                       cssClass: 'slick-header-column',
+                       headerCssClass: 'full-height-header'}];
 
   var sgCols = [];
 
   for (var i = 0; i < this.cols; i++) {
     // We need to add the plate Viewer as an element of this list so it gets
     // available in the formatter.
-    sgCols.push({plateViewer: this, id: i, name: i+1, field: i, editor: SampleCellEditor, formatter: this.wellFormatter});
+    sgCols.push({
+      plateViewer: this,
+      id: i,
+      name: i+1,
+      field: i,
+      editor: SampleCellEditor,
+      formatter: this.wellFormatter,
+      width:100,
+      minWidth: 80,
+      headerCssClass: 'full-height-header'});
   }
   var rowId = 'A';
 


### PR DESCRIPTION
A handful of usability improvements in the main grid:

- Make the width of the columns adjustable.
- Improve the default width by 25% (from 80 to 100 pixels).
- Make the text in the column headers fully visible.

Animated gif for reference:

![more-space](https://user-images.githubusercontent.com/375307/37945747-922f673a-3136-11e8-8c65-fe00d1cbdeee.gif)


Fixes #210