### PR TITLE
Fix for Issue 214

### DIFF
--- a/labman/db/plate.py
+++ b/labman/db/plate.py
@@ -379,13 +379,14 @@ class Plate(base.LabmanObject):
             return process_module.Process.factory(TRN.execute_fetchlast())
 
     @property
-    def quantification_process(self):
-        """The quantification process(es) of the plate
+    def quantification_processes(self):
+        """The quantification process(es) applied to (wells on) the plate
 
         Returns
         -------
-        QuantificationProcess
-            The quantification process of the plate, if exists. None, otherwise
+        list of QuantificationProcess
+            The quantification processes applied to (wells on) the plate,
+            in order from least to most recent. Empty list if none exist.
         """
         with sql_connection.TRN as TRN:
             sql = """SELECT DISTINCT cc.upstream_process_id
@@ -395,10 +396,10 @@ class Plate(base.LabmanObject):
                         JOIN qiita.well USING (container_id)
                      WHERE plate_id = %s"""
             TRN.add(sql, [self.id])
-            res = TRN.execute_fetchindex()
-            if res:
-                return process_module.QuantificationProcess(res[0][0])
-            return None
+            res = [process_module.QuantificationProcess(process_id)
+                   for process_id in TRN.execute_fetchflatten()]
+            res.sort(key=lambda x: x.date)
+        return res
 
     @property
     def duplicates(self):

--- a/labman/db/tests/test_plate.py
+++ b/labman/db/tests/test_plate.py
@@ -266,7 +266,7 @@ class TestPlate(LabmanTestCase):
         for row in obs_layout:
             self.assertEqual(len(row), 12)
         self.assertEqual(tester.studies, {Study(1)})
-        self.assertIsNone(tester.quantification_process)
+        self.assertListEqual(tester.quantification_processes, [])
         self.assertEqual(tester.process, SamplePlatingProcess(10))
 
         # Test changing the name of the plate
@@ -275,7 +275,8 @@ class TestPlate(LabmanTestCase):
         tester.external_id = 'Test plate 1'
         self.assertEqual(tester.external_id, 'Test plate 1')
 
-        self.assertEqual(Plate(23).quantification_process,
+        self.assertEqual(len(Plate(23).quantification_processes), 1)
+        self.assertEqual(Plate(23).quantification_processes[0],
                          QuantificationProcess(1))
         self.assertEqual(Plate(22).process, GDNAExtractionProcess(1))
 
@@ -357,6 +358,15 @@ class TestPlate(LabmanTestCase):
         exp.composition.update('Unknown')
         self.assertEqual(tester.unknown_samples, [exp])
         exp.composition.update('1.SKB1.640202')
+
+        # test that the quantification_processes attribute correctly
+        # orders multiple processes in order from oldest to newest
+        tester2 = Plate(26)
+        self.assertEqual(len(tester2.quantification_processes), 2)
+        self.assertEqual(tester2.quantification_processes[0].date.strftime(
+            '%Y-%m-%d'), "2017-10-25")
+        self.assertEqual(tester2.quantification_processes[1].date.strftime(
+            '%Y-%m-%d'), "2017-10-26")
 
     def test_get_well(self):
         # Plate 21 - Defined in the test DB

--- a/labman/gui/handlers/plate.py
+++ b/labman/gui/handlers/plate.py
@@ -177,6 +177,8 @@ class PlateHandler(BaseHandler):
              [{'plate_id': p.id, 'plate_name': p.external_id} for p in plates]]
             for w, plates in plate.get_previously_plated_wells().items()]
         unknowns = [[well.row, well.column] for well in plate.unknown_samples]
+        quantitation_processes = [[q.id, q.personnel.name, q.date.strftime(
+            '%Y-%m-%d'), q.notes] for q in plate.quantification_processes]
 
         plate_config = plate.plate_configuration
         result = {'plate_id': plate.id,
@@ -189,7 +191,8 @@ class PlateHandler(BaseHandler):
                   'studies': sorted(s.id for s in plate.studies),
                   'duplicates': duplicates,
                   'previous_plates': previous_plates,
-                  'unknowns': unknowns}
+                  'unknowns': unknowns,
+                  'quantitation_processes': quantitation_processes}
 
         self.write(result)
         self.finish()

--- a/labman/gui/handlers/process_handlers/__init__.py
+++ b/labman/gui/handlers/process_handlers/__init__.py
@@ -17,7 +17,7 @@ from .quantification_process import (
     QuantificationProcessParseHandler, QuantificationProcessHandler)
 from .pooling_process import (
     PoolPoolProcessHandler, LibraryPoolProcessHandler,
-    ComputeLibraryPoolValueslHandler, DownloadPoolFileHandler)
+    ComputeLibraryPoolValuesHandler, DownloadPoolFileHandler)
 from .sequencing_process import (
     SequencingProcessHandler, DownloadSampleSheetHandler,
     DownloadPreparationSheetsHandler)
@@ -36,7 +36,7 @@ __all__ = ['SamplePlatingProcessListHandler', 'SamplePlatingProcessHandler',
            'GDNAPlateCompressionProcessHandler',
            'PrimerWorkingPlateCreationProcessHandler',
            'EquipmentCreationProcessHandler',
-           'ComputeLibraryPoolValueslHandler', 'DownloadPoolFileHandler']
+           'ComputeLibraryPoolValuesHandler', 'DownloadPoolFileHandler']
 
 
 PROCESS_ENDPOINTS = [
@@ -47,7 +47,7 @@ PROCESS_ENDPOINTS = [
     (r"/process/library_prep_16S$", LibraryPrep16SProcessHandler),
     (r"/process/parse_quantify$", QuantificationProcessParseHandler),
     (r"/process/quantify$", QuantificationProcessHandler),
-    (r"/process/compute_pool$", ComputeLibraryPoolValueslHandler),
+    (r"/process/compute_pool$", ComputeLibraryPoolValuesHandler),
     (r"/process/poolpools$", PoolPoolProcessHandler),
     (r"/process/poollibraries$", LibraryPoolProcessHandler),
     (r"/process/poollibraries/([0-9]+)/pool_file$", DownloadPoolFileHandler),

--- a/labman/gui/handlers/process_handlers/normalization_process.py
+++ b/labman/gui/handlers/process_handlers/normalization_process.py
@@ -10,9 +10,8 @@ from tornado.web import authenticated, HTTPError
 from tornado.escape import json_decode, json_encode
 
 from labman.gui.handlers.base import BaseHandler
-from labman.db.process import NormalizationProcess
+from labman.db.process import NormalizationProcess, QuantificationProcess
 from labman.db.composition import ReagentComposition
-from labman.db.plate import Plate
 from labman.db.exceptions import LabmanUnknownIdError
 
 
@@ -52,12 +51,13 @@ class NormalizationProcessHandler(BaseHandler):
 
         processes = [
             [plate_id, NormalizationProcess.create(
-                user, Plate(plate_id).quantification_process,
+                user, QuantificationProcess(quantification_process_id),
                 ReagentComposition.from_external_id(water),
                 plate_name, total_vol=float(total_vol), ng=float(ng),
                 min_vol=float(min_vol), max_vol=float(max_vol),
                 resolution=float(resolution), reformat=reformat).id]
-            for plate_id, plate_name in json_decode(plates_info)]
+            for plate_id, plate_name, quantification_process_id in
+            json_decode(plates_info)]
 
         self.write({'processes': processes})
 

--- a/labman/gui/handlers/process_handlers/test/test_normalization.py
+++ b/labman/gui/handlers/process_handlers/test/test_normalization.py
@@ -34,7 +34,7 @@ class TestNormalizationHandlers(TestHandlerBase):
         self.assertEqual(response.code, 404)
 
     def test_post_normalization_handler(self):
-        data = {'plates_info': json_encode([[23, '157022406']]),
+        data = {'plates_info': json_encode([[23, '157022406', 1]]),
                 'water': 'RNBF7110', 'total_vol': 3500, 'ng': 5,
                 'min_vol': 2.5, 'max_vol': 3500, 'resolution': 2.5,
                 'reformat': False}

--- a/labman/gui/handlers/process_handlers/test/test_pooling_process.py
+++ b/labman/gui/handlers/process_handlers/test/test_pooling_process.py
@@ -79,7 +79,8 @@ class TestPoolingProcessHandlers(TestHandlerBase):
     def test_post_library_pool_process_handler(self):
         # Amplicon test
         data = {'plates-info': json_encode([{
-            'plate-id': 23, 'pool-func': 'amplicon', 'dna-amount-23': 240,
+            'plate-id': 23, 'pool-func': 'amplicon', 'quant-process-id': 1,
+            'dna-amount-23': 240,
             'min-val-23': 1, 'max-val-23': 15, 'blank-val-23': 2,
             'epmotion-23': 10, 'dest-tube-23': 1}])}
         response = self.post('/process/poollibraries', data)
@@ -90,8 +91,8 @@ class TestPoolingProcessHandlers(TestHandlerBase):
 
         # Shotgun test
         data = {'plates-info': json_encode([{
-            'plate-id': 26, 'pool-func': 'equal', 'volume-26': 200,
-            'lib-size-26': 500}])}
+            'plate-id': 26, 'pool-func': 'equal', 'quant-process-id': 5,
+            'volume-26': 200, 'lib-size-26': 500}])}
         response = self.post('/process/poollibraries', data)
         self.assertEqual(response.code, 200)
         obs = json_decode(response.body)
@@ -100,7 +101,8 @@ class TestPoolingProcessHandlers(TestHandlerBase):
 
         # Failure amplicon
         data = {'plates-info': json_encode([{
-            'plate-id': 23, 'pool-func': 'amplicon', 'dna-amount-23': 240,
+            'plate-id': 23, 'pool-func': 'amplicon', 'quant-process-id': 1,
+            'dna-amount-23': 240,
             'min-val-23': 1, 'max-val-23': 15, 'blank-val-23': 2,
             'epmotion-23': 10}])}
         response = self.post('/process/poollibraries', data)
@@ -108,23 +110,26 @@ class TestPoolingProcessHandlers(TestHandlerBase):
 
         # Failure shotgun
         data = {'plates-info': json_encode([{
-            'plate-id': 26, 'pool-func': 'equal', 'volume-26': 200}])}
+            'plate-id': 26, 'pool-func': 'equal', 'quant-process-id': 5,
+            'volume-26': 200}])}
         response = self.post('/process/poollibraries', data)
         self.assertEqual(response.code, 400)
 
     def test_post_compute_library_pool_values_handler(self):
         data = {'plate-info': json_encode({
-            'plate-id': 23, 'pool-func': 'amplicon', 'dna-amount-23': 240,
+            'plate-id': 23, 'pool-func': 'amplicon', 'quant-process-id': 1,
+            'dna-amount-23': 240,
             'min-val-23': 1, 'max-val-23': 15, 'blank-val-23': 2,
             'epmotion-23': 10, 'dest-tube-23': 1})}
         response = self.post('/process/compute_pool', data)
         self.assertEqual(response.code, 200)
         self.assertCountEqual(json_decode(response.body),
-                              ['plate_id', 'pool_vals', 'pool_blanks',
-                               'plate_names'])
+                              ['plate_id', 'quant-process-id', 'pool_vals',
+                               'pool_blanks', 'plate_names'])
 
         data = {'plate-info': json_encode({
-            'plate-id': 23, 'pool-func': 'amplicon', 'dna-amount-23': 240,
+            'plate-id': 23, 'pool-func': 'amplicon', 'quant-process-id': 1,
+            'dna-amount-23': 240,
             'min-val-23': 1, 'max-val-23': 15, 'blank-val-23': 2,
             'epmotion-23': 10})}
         response = self.post('/process/compute_pool', data)

--- a/labman/gui/templates/library_pooling.html
+++ b/labman/gui/templates/library_pooling.html
@@ -97,7 +97,9 @@
       poolFunc = $(elem).find('select').val();
     }
 
-    var plateInfo = {'plate-id': plateId, 'pool-func': poolFunc};
+    var quantitation_process = $("input[name='quantificationProcessForPlateId" +plateId + "']:checked").val();
+    var plateInfo = {'plate-id': plateId, 'pool-func': poolFunc,
+                    'quant-process-id': quantitation_process};
     $.each(poolParams[poolFunc], function(idx, paramElem) {
       parameterName = paramElem['prefix'] + plateId;
       plateInfo[parameterName] = $('#' + parameterName).val();
@@ -281,8 +283,53 @@
       }
       // Add a space for the pooling function results
       $('<div>').addClass('form-group').appendTo($formDiv).attr('id', 'pool-results-' + plateId);
+
+      // Set up skeleton of a table of quantifications done for this plate, each with a *radio button* (NB: not checkbox).
+      var quantificationsDivId = "quantificationsDivPlate" + plateId;
+      var $quantDivElem = $("<div>");
+      $quantDivElem.attr('id', quantificationsDivId);
+      var quantificationsTableId = "quantificationsTablePlate" + plateId;
+      $quantDivElem.append('<table id="' + quantificationsTableId + '" cellspacing="0" width="100%">\n' +
+          '      <thead>\n' +
+          '        <tr>\n' +
+          '          <th></th>\n' +
+          '          <th>Quantification</th>\n' +
+          '          <th>User</th>\n' +
+          '          <th>Date</th>\n' +
+          '          <th>Notes</th>\n' +
+          '        </tr>\n' +
+          '      </thead>\n' +
+          '    </table>\n' +
+          '</div>');
+
+
+      // add the quantification div element to the new plate element
+      $divElem.append($quantDivElem);
+
       // Add the element to the plate list
       $('#plate-list').append($divElem);
+
+      // populate the quantification table now that the element it
+      // is in is in the DOM.
+      var datatable = $('#' + quantificationsTableId).DataTable({
+          "paging": false,
+          "searching": false,
+          "info": false
+      });
+      var newData = [];
+      for (var i = 0; i < data.quantitation_processes.length; i++) {
+          var row = data.quantitation_processes[i];
+          // build the radio button.
+          // By default, most recent--i.e., last--quantification is selected.
+          var checked_str = (i === (data.quantitation_processes.length - 1)) ? " checked" : "" ;
+          var radioButton = ('<input type="radio" name = "quantificationProcessForPlateId' + plateId + '" value = "' + row[0] + '" ' + checked_str + '></input>');
+          newData.push([radioButton, row[0], row[1], row[2], row[3]]);
+      }
+
+      datatable.clear();
+      datatable.rows.add(newData);
+      datatable.draw();
+
       // Disable the button to add the plate to the list
       $('#addBtnPlate' + plateId).prop('disabled', true);
       // Hide the modal to add plates

--- a/labman/gui/templates/normalization.html
+++ b/labman/gui/templates/normalization.html
@@ -32,7 +32,7 @@
     } else if (plateIds.length > 0){
       bootstrapAlert('Loading data...', 'info');
       // Add the initial plates to the list
-      var requests = []
+      var requests = [];
       for (var pId of plateIds) {
         requests.push(addPlate(pId));
       }
@@ -53,7 +53,10 @@
     var plateId;
     for (var item of $('#plate-list').children()) {
       plateId = item.getAttribute('pm-data-plate-id');
-      platesInfo.push([plateId, $('#plate-name-' + plateId).val()])
+      platesInfo.push(
+          [plateId, $('#plate-name-' + plateId).val(),
+              $("input[name='quantificationProcessForPlateId" +plateId + "']:checked").val()]
+      )
     }
 
     $.post('/process/normalize', {
@@ -98,8 +101,51 @@
       // Add the extracted normalized plate name
       createPlateNameInputDOM($formDiv, plateId, normalizationChecks, 'Normalized plate name', data.plate_name + ' (normalized gDNA)');
 
+      // Set up skeleton of a table of quantifications done for this plate, each with a *radio button* (NB: not checkbox).
+      var quantificationsDivId = "quantificationsDivPlate" + plateId;
+      var $quantDivElem = $("<div>");
+      $quantDivElem.attr('id', quantificationsDivId);
+      var quantificationsTableId = "quantificationsTablePlate" + plateId;
+      $quantDivElem.append('<table id="' + quantificationsTableId + '" cellspacing="0" width="100%">\n' +
+          '      <thead>\n' +
+          '        <tr>\n' +
+          '          <th></th>\n' +
+          '          <th>Quantification</th>\n' +
+          '          <th>User</th>\n' +
+          '          <th>Date</th>\n' +
+          '          <th>Notes</th>\n' +
+          '        </tr>\n' +
+          '      </thead>\n' +
+          '    </table>\n' +
+          '</div>');
+
+
+      // add the quantification div element to the new plate element
+      $divElem.append($quantDivElem);
+
       // Add the element to the plate list
       $('#plate-list').append($divElem);
+
+      // populate the quantification table now that the element it
+      // is in is in the DOM.
+      var datatable = $('#' + quantificationsTableId).DataTable({
+          "paging": false,
+          "searching": false,
+          "info": false
+      });
+      var newData = [];
+      for (var i = 0; i < data.quantitation_processes.length; i++) {
+          var row = data.quantitation_processes[i];
+          // build the radio button.
+          // By default, most recent--i.e., last--quantification is selected.
+          var checked_str = (i === (data.quantitation_processes.length - 1)) ? " checked" : "" ;
+          var radioButton = ('<input type="radio" name = "quantificationProcessForPlateId' + plateId + '" value = "' + row[0] + '" ' + checked_str + '></input>');
+          newData.push([radioButton, row[0], row[1], row[2], row[3]]);
+      }
+
+      datatable.clear();
+      datatable.rows.add(newData);
+      datatable.draw();
 
       // Hide the modal to add plates
       $('#addPlateModal').modal('hide');

--- a/labman/gui/templates/plate_search.html
+++ b/labman/gui/templates/plate_search.html
@@ -173,7 +173,7 @@
             var datatable = $('#plateListTable').DataTable();
             var newData = [];
             for (var row of data.data) {
-              // Add the checkbox
+              // Add the view button
               var chBox = ('<a href="/plate/' + row[0] + '/process" class="btn btn-info btn-circle-small">' +
                             '<span class="glyphicon glyphicon-eye-open" data-toggle="tooltip" title="View plate process"></span>' +
                            '</a>');

--- a/labman/gui/test/test_plate.py
+++ b/labman/gui/test/test_plate.py
@@ -290,7 +290,8 @@ class TestPlateHandlers(TestHandlerBase):
                     [5, 12, '1.SKD3.640198.21.E12'],
                     [6, 12, '1.SKD3.640198.21.F12']],
                'previous_plates': [],
-               'unknowns': []}
+               'unknowns': [],
+               'quantitation_processes': []}
         obs_duplicates = obs.pop('duplicates')
         exp_duplicates = exp.pop('duplicates')
         self.assertEqual(obs, exp)
@@ -299,6 +300,28 @@ class TestPlateHandlers(TestHandlerBase):
         # Plate doesn't exist
         response = self.get('/plate/100/')
         self.assertEqual(response.code, 404)
+
+        # Plate has multiple quantitation processes
+        response = self.get('/plate/26/')
+        self.assertEqual(response.code, 200)
+        obs = json_decode(response.body)
+        exp = {'plate_id': 26,
+               'plate_name': 'Test shotgun library plate 1',
+               'discarded': False,
+               'plate_configuration': [3, '384-well microtiter plate', 16, 24],
+               'notes': None,
+               'studies': [1],
+               'duplicates': [],
+               'previous_plates': [],
+               'unknowns': [],
+               'quantitation_processes': [
+                   [4, 'Dude', '2017-10-25', None],
+                   [5, 'Dude', '2017-10-26', 'Requantification--oops']]
+               }
+        obs_duplicates = obs.pop('duplicates')
+        exp_duplicates = exp.pop('duplicates')
+        self.assertEqual(obs, exp)
+        self.assertCountEqual(obs_duplicates, exp_duplicates)
 
     def test_patch_plate_handler(self):
         tester = Plate(21)


### PR DESCRIPTION
Fixes #214 by adding support for Plate objects having quantitation_processes property rather than (incorrect) single quantitation_process, and user selecting the appropriate quantitation process for each plate during normalization and pooling. Also corrects spelling of ComputeLibraryPoolValuesHandler (was ComputeLibraryPoolValueslHandler).