### PR TITLE
handle warnings for divide by zero in pooling, fixes issue #233

### DIFF
--- a/labman/db/process.py
+++ b/labman/db/process.py
@@ -1887,7 +1887,11 @@ class QuantificationProcess(Process):
         np.array of floats
             A 2D array of floats
         """
-        return float(dna_amount) / sample_concs
+        old_err = np.seterr(divide='ignore')
+        out = float(dna_amount) / sample_concs
+        np.seterr(**old_err)
+
+        return out
 
 
 class PoolingProcess(Process):
@@ -2013,6 +2017,9 @@ class PoolingProcess(Process):
         sample_vols: np.array of floats
             the volumes in nL per each sample pooled
         """
+
+        old_err = np.seterr(divide='ignore')
+
         if sample_fracs is None:
             sample_fracs = np.ones(sample_concs.shape)
 
@@ -2025,6 +2032,9 @@ class PoolingProcess(Process):
         sample_vols *= vol_constant
         # drop volumes for samples below floor concentration to floor_vol
         sample_vols[sample_concs < floor_conc] = floor_vol
+
+        np.seterr(**old_err)
+
         return sample_vols
 
     @staticmethod

--- a/labman/db/process.py
+++ b/labman/db/process.py
@@ -1996,22 +1996,20 @@ class PoolingProcess(Process):
             the volumes in nL per each sample pooled
         """
 
-        old_err = np.seterr(divide='ignore')
-
         if sample_fracs is None:
             sample_fracs = np.ones(sample_concs.shape)
 
         if not total_each:
             sample_fracs = sample_fracs / sample_concs.size
 
-        # calculate volumetric fractions including floor val
-        sample_vols = (total * sample_fracs) / sample_concs
+        with np.errstate(divide='ignore'):
+            # calculate volumetric fractions including floor val
+            sample_vols = (total * sample_fracs) / sample_concs
+
         # convert volume from concentration units to pooling units
         sample_vols *= vol_constant
         # drop volumes for samples below floor concentration to floor_vol
         sample_vols[sample_concs < floor_conc] = floor_vol
-
-        np.seterr(**old_err)
 
         return sample_vols
 

--- a/labman/db/process.py
+++ b/labman/db/process.py
@@ -1871,28 +1871,6 @@ class QuantificationProcess(Process):
                 TRN.add(sql, sql_args, many=True)
                 TRN.execute()
 
-    @staticmethod
-    def _compute_amplicon_pool_values(sample_concs, dna_amount=240):
-        """Computes amplicon pooling values
-
-        Parameters
-        ----------
-        sample_concs: 2D array of float
-            nM sample concentrations
-        dna_amount: float, optional
-            Total amount of DNA, in ng. Default: 240
-
-        Returns
-        -------
-        np.array of floats
-            A 2D array of floats
-        """
-        old_err = np.seterr(divide='ignore')
-        out = float(dna_amount) / sample_concs
-        np.seterr(**old_err)
-
-        return out
-
 
 class PoolingProcess(Process):
     """Pooling process object


### PR DESCRIPTION
This: 

1. temporary changes numpy behavior to 'ignore' divide-by-zero warnings in the `compute_pooling_values_minvol` method. This leaves calculated volumes as `inf`.

2. removes deprecated static method `_compute_amplicon_pool_values`

I think the default numpy divide behavior here is the desired behavior -- producing `inf` volume values for cases where the measured concentration is zero.

Currently, these values get replaced by the 'floor_vol' value when 'floor_conc' is > 0. Maybe we should also add a constraint that requires `floor_conc` to be > 0?