### PR TITLE
BUG: Cleanup grid container before updating

### DIFF
--- a/labman/gui/static/js/plate.js
+++ b/labman/gui/static/js/plate.js
@@ -113,6 +113,8 @@ function change_plate_configuration() {
   if (plateId !== undefined) {
     throw "Can't change the plate configuration of an existing plate"
   } else {
+    // reset the container before updating the grid configuration
+    $('#plate-map-div').empty().height(0);
     pv = new PlateViewer('plate-map-div', undefined, undefined, $opt.attr('pm-data-rows'), $opt.attr('pm-data-cols'));
   }
 }


### PR DESCRIPTION
The grid wasn't being removed from the container after the plate
configuration changed. Leading to a stack of grids being added in the
UI.

Looks like this:
![241](https://user-images.githubusercontent.com/375307/42533052-9e878152-843d-11e8-8e3f-30b0610bce43.gif)


Fixes #241 
