### PR TITLE
BUG: Fix broken copy-paste

### DIFF
--- a/labman/gui/static/js/plateViewer.js
+++ b/labman/gui/static/js/plateViewer.js
@@ -131,9 +131,16 @@ PlateViewer.prototype.initialize = function (rows, cols) {
 
   // Fetch the blank names before initializing the grid. This way we only make
   // one request to get this data instead of one per cell instantiation.
-  var blanksRequest = $.ajax({
+  // When no search term is specified in the request, we get all available
+  // blank types.
+  var blanksRequest = $.get({
     dataType: 'json',
     url: '/sample/control?term=',
+    error: function(jqXHR, textStatus, errorThrown) {
+     bootstrapAlert('Could not fetch known <i>Control Types</i> needed for ' +
+                    'plating samples. Try reloading the page. <br>' +
+                    jqXHR.responseText, 'danger');
+    }
   });
 
   var sgCols = [];

--- a/labman/gui/static/js/plateViewer.js
+++ b/labman/gui/static/js/plateViewer.js
@@ -129,6 +129,13 @@ PlateViewer.prototype.initialize = function (rows, cols) {
                        cssClass: 'slick-header-column',
                        headerCssClass: 'full-height-header'}];
 
+  // Fetch the blank names before initializing the grid. This way we only make
+  // one request to get this data instead of one per cell instantiation.
+  var blanksRequest = $.ajax({
+    dataType: 'json',
+    url: '/sample/control?term=',
+  });
+
   var sgCols = [];
 
   for (var i = 0; i < this.cols; i++) {
@@ -140,6 +147,7 @@ PlateViewer.prototype.initialize = function (rows, cols) {
       name: i+1,
       field: i,
       editor: SampleCellEditor,
+      options: {'blankNamesRequest': blanksRequest},
       formatter: this.wellFormatter,
       width:100,
       minWidth: 80,
@@ -536,13 +544,9 @@ function SampleCellEditor(args) {
   // to choose the sample from the autocomplete dropdown menu
   this.keyCaptureList = [Slick.keyCode.UP, Slick.keyCode.DOWN];
 
-  this.blanknames = [];
-  $.ajax({
-    url: '/sample/control?term=',
-    success: function (result) {
-      that.blankNames = result;
-    }
-  });
+  // Get the parsed values from the request. Alternatively, if the request
+  // didn't complete yet use an empty list as a fallback.
+  this.blankNames = args.column.options.blankNamesRequest.responseJSON || [];
 
   // styling taken from SlickGrid's examples/examples.css file
   this.init = function () {


### PR DESCRIPTION
The assignment of the `this.blankNames` property was being done
asynchronously on a per-cell basis. This worked fine if the user inputed
a value by hand, as it gave enough time for the request to return.
However, when someone copy-pasted text into the grid, the request
wouldn't return in time and the `this.blankNames` property wouldn't be
correctly assigned leading to a ReferenceError.

This is now fixed by getting the contents of `this.blankNames` before
initializing the whole grid. This way every cell has access to the data
before instantiation.

![242](https://user-images.githubusercontent.com/375307/42590508-db507e52-84f8-11e8-8563-f9ff80e6df8e.gif)

Fixes #243 
