### PR TITLE
Fixes issue 251: Extend pool list to offer re-download of pool files for plate pools

### DIFF
--- a/labman/db/composition.py
+++ b/labman/db/composition.py
@@ -1022,10 +1022,14 @@ class PoolComposition(Composition):
             [{'pool_id': int, 'external_id': string}]
         """
         with sql_connection.TRN as TRN:
-            sql = """SELECT pool_composition_id, external_id
+            sql = """SELECT pool_composition_id, pooling_process_id, 
+                     external_id 
                      FROM qiita.pool_composition
                         JOIN qiita.composition USING (composition_id)
                         JOIN qiita.tube USING (container_id)
+                        JOIN qiita.process ON 
+                          upstream_process_id = qiita.process.process_id
+                        JOIN qiita.pooling_process USING (process_id) 
                      ORDER BY pool_composition_id"""
             TRN.add(sql)
             return [dict(r) for r in TRN.execute_fetchindex()]

--- a/labman/db/composition.py
+++ b/labman/db/composition.py
@@ -1029,6 +1029,13 @@ class PoolComposition(Composition):
 
     @staticmethod
     def get_pools():
+        """Return list of all pool compositions as PoolComposition objects
+
+        Returns
+        -------
+        list of labman.db.composition.PoolComposition
+            Ordered by pool_composition_id
+        """
         with sql_connection.TRN as TRN:
             sql = """SELECT pool_composition_id
                      FROM qiita.pool_composition
@@ -1104,6 +1111,12 @@ class PoolComposition(Composition):
 
     @property
     def is_plate_pool(self):
+        """Return True if pool components are PoolCompositions, else False
+
+        Returns
+        -------
+        True if pool components are PoolCompositions, else False
+        """
         composition_components = [x["composition"] for x in self.components]
         component_type = self.get_components_type(composition_components)
         result = component_type != PoolComposition

--- a/labman/db/process.py
+++ b/labman/db/process.py
@@ -2242,6 +2242,8 @@ class PoolingProcess(Process):
         return self._get_attr('destination')
 
     @property
+    # TODO: Someday: Seems suboptimal that this and the code in
+    # PoolComposition.components are very similar
     def components(self):
         """The components of the pool
 
@@ -2378,17 +2380,18 @@ class PoolingProcess(Process):
         str
             The contents of the pool file
         """
-        comp = self.components[0][0]
-        if isinstance(comp, composition_module.LibraryPrep16SComposition):
+        component_compositions = [x[0] for x in self.components]
+        comp_class = composition_module.PoolComposition\
+            .get_components_type(component_compositions)
+        if comp_class == composition_module.LibraryPrep16SComposition:
             return self.generate_epmotion_file()
-        elif isinstance(comp,
-                        composition_module.LibraryPrepShotgunComposition):
+        elif comp_class == composition_module.LibraryPrepShotgunComposition:
             return self.generate_echo_picklist()
         else:
             # This error should only be shown to programmers
             raise ValueError(
                 "Can't generate a pooling file for a pool containing "
-                "compositions of type: %s" % comp.__class__.__name__)
+                "compositions of type: %s" % comp_class)
 
 
 class SequencingProcess(Process):
@@ -2655,7 +2658,7 @@ class SequencingProcess(Process):
             demultiplexed samples
         description: array-like, optional
             The original sample ids, in sample_ids order. Default: None
-        lanes: array-lie, optional
+        lanes: array-like, optional
             The lanes in which the pool will be sequenced. Default: [1]
         sep: str, optional
             The file-format separator. Default: ','

--- a/labman/db/tests/test_composition.py
+++ b/labman/db/tests/test_composition.py
@@ -295,10 +295,13 @@ class TestsComposition(LabmanTestCase):
     def test_pool_composition_pools(self):
         obs = PoolComposition.list_pools()
         exp = [{'pool_composition_id': 1,
+                'pooling_process_id': 1,
                 'external_id': 'Test Pool from Plate 1'},
                {'pool_composition_id': 2,
+                'pooling_process_id': 2,
                 'external_id': 'Test sequencing pool 1'},
                {'pool_composition_id': 3,
+                'pooling_process_id': 3,
                 'external_id': 'Test pool from Shotgun plate 1'}]
         self.assertEqual(obs, exp)
 

--- a/labman/db/tests/test_composition.py
+++ b/labman/db/tests/test_composition.py
@@ -292,18 +292,18 @@ class TestsComposition(LabmanTestCase):
         self.assertEqual(obs.composition_id, 3086)
         self.assertEqual(obs.study, Study(1))
 
+    def test_pool_composition_get_components_type(self):
+        obs1 = PoolComposition.get_components_type([PoolComposition(1)])
+        self.assertEqual(obs1, PoolComposition)
+        obs2 = PoolComposition.get_components_type(
+            [LibraryPrep16SComposition(1)])
+        self.assertEqual(obs2, LibraryPrep16SComposition)
+
     def test_pool_composition_pools(self):
-        obs = PoolComposition.list_pools()
-        exp = [{'pool_composition_id': 1,
-                'pooling_process_id': 1,
-                'external_id': 'Test Pool from Plate 1'},
-               {'pool_composition_id': 2,
-                'pooling_process_id': 2,
-                'external_id': 'Test sequencing pool 1'},
-               {'pool_composition_id': 3,
-                'pooling_process_id': 3,
-                'external_id': 'Test pool from Shotgun plate 1'}]
-        self.assertEqual(obs, exp)
+        obs = PoolComposition.get_pools()
+        obs_ids = [x.id for x in obs]
+        exp_ids = [1, 2, 3]
+        self.assertEqual(obs_ids, exp_ids)
 
     def test_pool_composition_attributes(self):
         obs = PoolComposition(1)
@@ -317,6 +317,14 @@ class TestsComposition(LabmanTestCase):
                'input_volume': 1.0, 'percentage_of_output': 0}
         self.assertEqual(obs_comp[0], exp)
         self.assertEqual(obs.raw_concentration, 25.0)
+
+    def test_pool_composition_attributes_is_plate_pool(self):
+        obs1 = PoolComposition(1)  # of 16s
+        self.assertTrue(obs1.is_plate_pool)
+        obs2 = PoolComposition(2)  # of pools
+        self.assertFalse(obs2.is_plate_pool)
+        obs3 = PoolComposition(3)  # of shotgun
+        self.assertTrue(obs3.is_plate_pool)
 
     def test_primer_set_attributes(self):
         obs = PrimerSet(1)

--- a/labman/db/tests/test_process.py
+++ b/labman/db/tests/test_process.py
@@ -1117,6 +1117,7 @@ class TestPoolingProcess(LabmanTestCase):
                                          pool_concs,
                                          pool_blanks,
                                          2)
+
     def test_attributes(self):
         tester = PoolingProcess(1)
         self.assertEqual(tester.date,

--- a/labman/gui/handlers/pool.py
+++ b/labman/gui/handlers/pool.py
@@ -22,7 +22,8 @@ class PoolListingHandler(BaseHandler):
 class PoolListHandler(BaseHandler):
     @authenticated
     def get(self):
-        res = {"data": [[p['pool_composition_id'], p['external_id']]
+        res = {"data": [[p['pooling_process_id'], p['pool_composition_id'],
+                         p['external_id']]
                         for p in PoolComposition.list_pools()]}
         self.write(res)
 

--- a/labman/gui/handlers/pool.py
+++ b/labman/gui/handlers/pool.py
@@ -22,9 +22,11 @@ class PoolListingHandler(BaseHandler):
 class PoolListHandler(BaseHandler):
     @authenticated
     def get(self):
-        res = {"data": [[p['pooling_process_id'], p['pool_composition_id'],
-                         p['external_id']]
-                        for p in PoolComposition.list_pools()]}
+        res = {"data": [
+            [p.id, p.container.external_id, p.is_plate_pool,
+             p.upstream_process.id, ]
+            for p in PoolComposition.get_pools()
+        ]}
         self.write(res)
 
 

--- a/labman/gui/templates/pool_list.html
+++ b/labman/gui/templates/pool_list.html
@@ -13,11 +13,14 @@
       var newData = [];
       for (var row of data.data) {
         // Add the checkbox
-        var chBox = '<input type="checkbox" class="table-checkbox" data-lb-pool-id="' + row[1] + '"></input>';
-        var poolFile = '<a href="/process/poollibraries/' + row[0] + '/pool_file" class="btn btn-success">' +
-          '<span class="glyphicon glyphicon-download"></span> ' +
-          'Download Pool File</a>';
-        newData.push([chBox, row[1], row[2], poolFile]);
+        var chBox = '<input type="checkbox" class="table-checkbox" data-lb-pool-id="' + row[0] + '"></input>';
+        var poolFileButton = '';
+        if (row[2] === true){
+            poolFileButton = '<a href="/process/poollibraries/' + row[3] + '/pool_file" class="btn btn-success">' +
+            '<span class="glyphicon glyphicon-download"></span> ' +
+            'Download Pool File</a>';
+        }
+        newData.push([chBox, row[0], row[1], poolFileButton]);
       }
       datatable.clear();
       datatable.rows.add(newData);

--- a/labman/gui/templates/pool_list.html
+++ b/labman/gui/templates/pool_list.html
@@ -13,8 +13,11 @@
       var newData = [];
       for (var row of data.data) {
         // Add the checkbox
-        var chBox = '<input type="checkbox" class="table-checkbox" data-lb-pool-id="' + row[0] + '"></input>';
-        newData.push([chBox, row[0], row[1]]);
+        var chBox = '<input type="checkbox" class="table-checkbox" data-lb-pool-id="' + row[1] + '"></input>';
+        var poolFile = '<a href="/process/poollibraries/' + row[0] + '/pool_file" class="btn btn-success">' +
+          '<span class="glyphicon glyphicon-download"></span> ' +
+          'Download Pool File</a>';
+        newData.push([chBox, row[1], row[2], poolFile]);
       }
       datatable.clear();
       datatable.rows.add(newData);
@@ -25,7 +28,7 @@
           dtSelectedCounter += 1;
           if (dtSelectedCounter === 1) {
             $('<button>').addClass('btn btn-info').append('Prepare sequencing pool').appendTo('#btn-div').on('click', function () {
-              var poolIds = []
+              var poolIds = [];
               for (var inTag of $('.dt-selected').find('input')) {
                 poolIds.push($(inTag).attr('data-lb-pool-id'));
               }
@@ -59,6 +62,7 @@
       <th></th>
       <th>Pool id</th>
       <th>Pool name</th>
+      <th>Pool file</th>
     </tr>
   </thead>
 </table>

--- a/labman/gui/test/test_pool.py
+++ b/labman/gui/test/test_pool.py
@@ -1,0 +1,28 @@
+# ----------------------------------------------------------------------------
+# Copyright (c) 2017-, labman development team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file LICENSE, distributed with this software.
+# ----------------------------------------------------------------------------
+
+
+from unittest import main
+from tornado.escape import json_decode
+from labman.gui.testing import TestHandlerBase
+
+
+class TestPoolHandlers(TestHandlerBase):
+    def test_get_plate_list_handler(self):
+        response = self.get('/pool_list')
+        self.assertEqual(response.code, 200)
+        obs = json_decode(response.body)
+        self.assertCountEqual(obs.keys(), ['data'])
+        obs_data = obs['data']
+        self.assertEqual(len(obs_data), 3)
+        self.assertEqual(obs_data[0], [1, 'Test Pool from Plate 1', True, 1])
+        self.assertEqual(obs_data[1], [2, 'Test sequencing pool 1', False, 2])
+
+
+if __name__ == '__main__':
+    main()

--- a/labman/gui/test/test_pool.py
+++ b/labman/gui/test/test_pool.py
@@ -22,6 +22,8 @@ class TestPoolHandlers(TestHandlerBase):
         self.assertEqual(len(obs_data), 3)
         self.assertEqual(obs_data[0], [1, 'Test Pool from Plate 1', True, 1])
         self.assertEqual(obs_data[1], [2, 'Test sequencing pool 1', False, 2])
+        self.assertEqual(obs_data[2], [3, 'Test pool from Shotgun plate 1',
+                                       True, 3])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Pool list now looks like the below, with pool file download buttons for plate pools and none for sequencing pools:

<img width="970" alt="screen shot 2018-07-25 at 7 03 37 am" src="https://user-images.githubusercontent.com/10677935/43205817-149a1f70-8fd9-11e8-98f5-7543f7e2809a.png">
