### PR TITLE
Adds sample plating notes to the UI

### DIFF
--- a/labman/db/process.py
+++ b/labman/db/process.py
@@ -225,6 +225,11 @@ class _Process(Process):
     def notes(self):
         return self._get_attr('notes')
 
+    @notes.setter
+    def notes(self, value):
+        """Updates the notes of the process"""
+        self._set_attr('notes', value)
+
     @property
     def process_id(self):
         return self._get_attr('process_id')

--- a/labman/db/tests/test_process.py
+++ b/labman/db/tests/test_process.py
@@ -176,6 +176,13 @@ class TestSamplePlatingProcess(LabmanTestCase):
         tester.comment_well(8, 1, None)
         self.assertIsNone(obs.notes)
 
+    def test_notes(self):
+        tester = SamplePlatingProcess(10)
+
+        self.assertIsNone(tester.notes)
+        tester.notes = 'This note was set in a test'
+        self.assertEqual(tester.notes, 'This note was set in a test')
+
 
 class TestReagentCreationProcess(LabmanTestCase):
     def test_attributes(self):

--- a/labman/gui/handlers/plate.py
+++ b/labman/gui/handlers/plate.py
@@ -189,6 +189,7 @@ class PlateHandler(BaseHandler):
                         plate_config.id, plate_config.description,
                         plate_config.num_rows, plate_config.num_columns],
                   'notes': plate.notes,
+                  'process_notes': plate.process.notes,
                   'studies': sorted(s.id for s in plate.studies),
                   'duplicates': duplicates,
                   'previous_plates': previous_plates,

--- a/labman/gui/handlers/process_handlers/__init__.py
+++ b/labman/gui/handlers/process_handlers/__init__.py
@@ -6,8 +6,9 @@
 # The full license is in the file LICENSE, distributed with this software.
 # ----------------------------------------------------------------------------
 
-from .sample_plating_process import (
-    SamplePlatingProcessListHandler, SamplePlatingProcessHandler)
+from .sample_plating_process import (SamplePlatingProcessNotes,
+                                     SamplePlatingProcessListHandler,
+                                     SamplePlatingProcessHandler)
 from .gdna_extraction_process import GDNAExtractionProcessHandler
 from .gdna_compression_process import GDNAPlateCompressionProcessHandler
 from .library_prep_16s_process import LibraryPrep16SProcessHandler
@@ -29,6 +30,7 @@ from .primer_working_plate_creation_process import (
 from .equipment_creation_process import EquipmentCreationProcessHandler
 
 __all__ = ['SamplePlatingProcessListHandler', 'SamplePlatingProcessHandler',
+           'SamplePlatingProcessNotes',
            'GDNAExtractionProcessHandler', 'LibraryPrep16SProcessHandler',
            'QuantificationProcessParseHandler', 'QuantificationProcessHandler',
            'QuantificationViewHandler',
@@ -44,6 +46,7 @@ __all__ = ['SamplePlatingProcessListHandler', 'SamplePlatingProcessHandler',
 PROCESS_ENDPOINTS = [
     (r"/process/sample_plating/([0-9]+)$", SamplePlatingProcessHandler),
     (r"/process/sample_plating$", SamplePlatingProcessListHandler),
+    (r"/process/sample_plating/notes$", SamplePlatingProcessNotes),
     (r"/process/gdna_extraction$", GDNAExtractionProcessHandler),
     (r"/process/gdna_compression$", GDNAPlateCompressionProcessHandler),
     (r"/process/library_prep_16S$", LibraryPrep16SProcessHandler),

--- a/labman/gui/handlers/process_handlers/sample_plating_process.py
+++ b/labman/gui/handlers/process_handlers/sample_plating_process.py
@@ -13,6 +13,14 @@ from labman.db.process import SamplePlatingProcess
 from labman.db.plate import PlateConfiguration, Plate
 
 
+class SamplePlatingProcessNotes(BaseHandler):
+    @authenticated
+    def post(self):
+        process = SamplePlatingProcess(self.get_argument('process_id'))
+        process.notes = self.get_argument('notes')
+        self.finish()
+
+
 class SamplePlatingProcessListHandler(BaseHandler):
     @authenticated
     def post(self):

--- a/labman/gui/handlers/process_handlers/test/test_sample_plating_process.py
+++ b/labman/gui/handlers/process_handlers/test/test_sample_plating_process.py
@@ -108,6 +108,15 @@ class TestUtils(TestHandlerBase):
 
 
 class TestSamplePlatingProcessHandlers(TestHandlerBase):
+    def test_post_sample_plating_process_notes(self):
+        data = {'process_id': 1, 'notes': 'This is a test note'}
+        response = self.post('/process/sample_plating/notes', data)
+        self.assertEqual(response.code, 200)
+
+        data = {'process_id': 1, 'notes': None}
+        response = self.post('/process/sample_plating/notes', data)
+        self.assertEqual(response.code, 200)
+
     def test_post_sample_plating_process_list_handler(self):
         data = {'plate_name': 'New Plate name',
                 'plate_configuration': 1}

--- a/labman/gui/templates/extraction.html
+++ b/labman/gui/templates/extraction.html
@@ -151,6 +151,8 @@
       // Add the notes input
       createTextInputDOM($formDiv, plateId, extractionChecks, 'Notes', data.notes, 'notes-');
 
+      $divElem.append('<h6>Plating Notes:</h6>' + (data.process_notes || '(No notes found)'));
+
       // Add the element to the plate list
       $('#plate-list').append($divElem);
 

--- a/labman/gui/test/test_plate.py
+++ b/labman/gui/test/test_plate.py
@@ -292,6 +292,7 @@ class TestPlateHandlers(TestHandlerBase):
                     [5, 12, '1.SKD3.640198.21.E12'],
                     [6, 12, '1.SKD3.640198.21.F12']],
                'previous_plates': [],
+               'process_notes': None,
                'unknowns': [],
                'quantitation_processes': []}
         obs_duplicates = obs.pop('duplicates')
@@ -326,6 +327,7 @@ class TestPlateHandlers(TestHandlerBase):
                'studies': [1],
                'duplicates': [],
                'previous_plates': [],
+               'process_notes': None,
                'unknowns': [],
                'quantitation_processes': [
                    [4, 'Dude', first_date_str, None],


### PR DESCRIPTION
The user can now add notes to a plate during the plating process. These notes are later viewable when selecting plates in the extract gDNA UI. 

Here's an example of the new functionality. First I add a study to the plate, then add a sample, then when the process has been created the notes box is added to the UI. The user can add any text and save it with the "save" button.

Afterwards in the extract gDNA UI when a plate is selected the notes are shown at the bottom. See this animated gif for an example:

![notes](https://user-images.githubusercontent.com/375307/43303718-e3fd6554-9125-11e8-9909-76a993980e13.gif)