### PR TITLE
Sample plating improvements

### DIFF
--- a/labman/gui/handlers/plate.py
+++ b/labman/gui/handlers/plate.py
@@ -79,10 +79,14 @@ class PlateListHandler(BaseHandler):
         plate_type = (json_decode(plate_type)
                       if plate_type is not None else None)
         only_quantified = True if only_quantified == 'true' else False
-        res = {"data": [[p['plate_id'], p['external_id'], p['studies']]
-                        for p in Plate.list_plates(
+
+        rows_list = [[p['plate_id'], p['external_id'],
+                      p['studies'] if p['studies'] is not None else []]
+                     for p in Plate.list_plates(
                             plate_type, only_quantified=only_quantified,
-                            include_study_titles=True)]}
+                            include_study_titles=True)]
+        res = {"data": rows_list}
+
         self.write(res)
 
 

--- a/labman/gui/static/js/plate.js
+++ b/labman/gui/static/js/plate.js
@@ -116,5 +116,38 @@ function change_plate_configuration() {
     // reset the container before updating the grid configuration
     $('#plate-map-div').empty().height(0);
     pv = new PlateViewer('plate-map-div', undefined, undefined, $opt.attr('pm-data-rows'), $opt.attr('pm-data-cols'));
+    // Enable the plate create button now that a plate config is selected
+    $('#createPlateBtn').prop('disabled', false);
   }
+}
+
+function createPlate(){
+      var plateName = $('#newNameInput').val().trim();
+      var plateConf = $('#plate-conf-select option:selected').val();
+      $.post('/process/sample_plating', {'plate_name': plateName, 'plate_configuration': plateConf}, function (data) {
+        var plateId = data['plate_id'];
+        var processId = data['process_id'];
+
+        $('#plateName').prop('pm-data-plate-id', plateId);
+        $('#plateName').prop('pm-data-process-id', processId);
+        // Once the plate has been created, we can disable the plate config select
+        $('#plate-conf-select').prop('disabled', true);
+
+        // reset the container before updating the grid configuration
+        $('#plate-map-div').empty().height(0);
+        var $opt = $('#plate-conf-select option:selected');
+        var pv = new PlateViewer('plate-map-div', undefined, undefined, $opt.attr('pm-data-rows'), $opt.attr('pm-data-cols'));
+        pv.plateId = plateId;
+        pv.processId = processId;
+        // we can only instantiate the notes box when we have a process id
+        pv.notes = new NotesBox(pv.container.parent(),
+                                  '/process/sample_plating/notes',
+                                  processId);
+
+        // Disable the plate create button
+        $('#createPlateBtn').prop('disabled', true);
+
+        // Show the plate details div
+        $('#plateDetails').prop('hidden', false);
+      });
 }

--- a/labman/gui/static/js/plate.js
+++ b/labman/gui/static/js/plate.js
@@ -121,33 +121,47 @@ function change_plate_configuration() {
   }
 }
 
+/**
+ * Callback from the "Create" button in the sample plating page.
+ */
 function createPlate(){
-      var plateName = $('#newNameInput').val().trim();
-      var plateConf = $('#plate-conf-select option:selected').val();
-      $.post('/process/sample_plating', {'plate_name': plateName, 'plate_configuration': plateConf}, function (data) {
-        var plateId = data['plate_id'];
-        var processId = data['process_id'];
+  $('#createPlateBtn').prop('disabled', true);
 
-        $('#plateName').prop('pm-data-plate-id', plateId);
-        $('#plateName').prop('pm-data-process-id', processId);
-        // Once the plate has been created, we can disable the plate config select
-        $('#plate-conf-select').prop('disabled', true);
+  var plateName = $('#newNameInput').val().trim();
+  var plateConf = $('#plate-conf-select option:selected').val();
 
-        // reset the container before updating the grid configuration
-        $('#plate-map-div').empty().height(0);
-        var $opt = $('#plate-conf-select option:selected');
-        var pv = new PlateViewer('plate-map-div', undefined, undefined, $opt.attr('pm-data-rows'), $opt.attr('pm-data-cols'));
-        pv.plateId = plateId;
-        pv.processId = processId;
-        // we can only instantiate the notes box when we have a process id
-        pv.notes = new NotesBox(pv.container.parent(),
-                                  '/process/sample_plating/notes',
-                                  processId);
+  $.post(
+    '/process/sample_plating',
+    {'plate_name': plateName, 'plate_configuration': plateConf}
+  )
+  .done(function (data) {
+    var plateId = data['plate_id'];
+    var processId = data['process_id'];
 
-        // Disable the plate create button
-        $('#createPlateBtn').prop('disabled', true);
+    $('#plateName').prop('pm-data-plate-id', plateId);
+    $('#plateName').prop('pm-data-process-id', processId);
+    // Once the plate has been created, we can disable the plate config select
+    $('#plate-conf-select').prop('disabled', true);
 
-        // Show the plate details div
-        $('#plateDetails').prop('hidden', false);
-      });
+    // reset the container before updating the grid configuration
+    $('#plate-map-div').empty().height(0);
+    var $opt = $('#plate-conf-select option:selected');
+    var pv = new PlateViewer('plate-map-div', undefined, undefined, $opt.attr('pm-data-rows'), $opt.attr('pm-data-cols'));
+    pv.plateId = plateId;
+    pv.processId = processId;
+    // we can only instantiate the notes box when we have a process id
+    pv.notes = new NotesBox(pv.container.parent(),
+                            '/process/sample_plating/notes',
+                            processId);
+
+    // Disable the plate create button
+    $('#createPlateBtn').prop('disabled', true);
+
+    // Show the plate details div
+    $('#plateDetails').prop('hidden', false);
+  })
+  .fail(function(jqXHR, textStatus, errorThrown) {
+    $('#createPlateBtn').prop('disabled', false);
+    bootstrapAlert('Could not create plate. Error message:<br>' + jqXHR.responseText);
+  });
 }

--- a/labman/gui/static/js/plate.js
+++ b/labman/gui/static/js/plate.js
@@ -146,6 +146,13 @@ function createPlate(){
     // reset the container before updating the grid configuration
     $('#plate-map-div').empty().height(0);
     var $opt = $('#plate-conf-select option:selected');
+
+    // Create a new PlateViewer object *without* passing in plateId and
+    // processId, because if those are passed in to the object initializer,
+    // code assumes the plate has already been filled--and when it can't find
+    // contents, it populates all the wells with blanks :(.  Setting the
+    // plateId and processId after object initialization sets the necessary
+    // state but avoids this behavior.
     var pv = new PlateViewer('plate-map-div', undefined, undefined, $opt.attr('pm-data-rows'), $opt.attr('pm-data-cols'));
     pv.plateId = plateId;
     pv.processId = processId;

--- a/labman/gui/static/js/plateViewer.js
+++ b/labman/gui/static/js/plateViewer.js
@@ -741,6 +741,8 @@ function NotesBox(container, uri, id, options) {
     that.text = that.$textArea.val();
   });
 
+  this.$textArea.attr('placeholder', this.placeholder);
+
   this.$saveButton.on('click', function() {
     that.save();
     $(this).addClass('disabled');

--- a/labman/gui/static/js/plateViewer.js
+++ b/labman/gui/static/js/plateViewer.js
@@ -748,6 +748,22 @@ function NotesBox(container, uri, id, options) {
 }
 
 /**
+ * Method to set the text value to the object.
+ *
+ * @param {String} text The text you want set in the NotesBox.
+ * @param {Bool} save Whether or not the text should be saved to the server.
+ * Useful when preloading text into the UI. Default is False.
+ */
+NotesBox.prototype.setText = function(text, save) {
+  this.text = text;
+  this.$textArea.val(text);
+
+  if (save) {
+    this.save();
+  }
+};
+
+/**
  * Method to write the notes into the uri.
  */
 NotesBox.prototype.save = function () {

--- a/labman/gui/static/js/plateViewer.js
+++ b/labman/gui/static/js/plateViewer.js
@@ -14,8 +14,6 @@
  *
  **/
 function PlateViewer(target, plateId, processId, rows, cols) {
-  var height = '250px';
-
   this.container = $('#' + target);
 
   /*
@@ -30,16 +28,6 @@ function PlateViewer(target, plateId, processId, rows, cols) {
 
   this.container.append(this._frozenColumnTarget);
   this.container.append(this.target);
-
-  // Make sure all rows fit on screen. we need to have enough space so that we
-  // don't have to synchronize the scrolling events between the two elements
-  if (rows > 8) {
-    height = '450px';
-  }
-
-  this.container.height(height);
-  this.target.height(height);
-  this._frozenColumnTarget.height(height);
 
   this.plateId = null;
   this.processId = null;
@@ -101,6 +89,8 @@ function PlateViewer(target, plateId, processId, rows, cols) {
  **/
 PlateViewer.prototype.initialize = function (rows, cols) {
   var that = this;
+  var height = '250px';
+
   this.rows = rows;
   this.cols = cols;
   this.data = [];
@@ -108,6 +98,15 @@ PlateViewer.prototype.initialize = function (rows, cols) {
   this.wellComments = [];
   this.wellPreviousPlates = [];
   this.wellClasses = [];
+
+  // Make sure all rows fit on screen. we need to have enough space so that we
+  // don't have to synchronize the scrolling events between the two elements
+  if (rows > 8) {
+    height = '450px';
+  }
+  this.container.height(height);
+  this.target.height(height);
+  this._frozenColumnTarget.height(height);
 
   var sgOptions = {editable: true,
                    enableCellNavigation: true,

--- a/labman/gui/static/js/plateViewer.js
+++ b/labman/gui/static/js/plateViewer.js
@@ -263,33 +263,8 @@ PlateViewer.prototype.initialize = function (rows, cols) {
     var col = args.cell;
     var content = args.item[col];
 
-    if (that.plateId == null) {
-      // This is a new plate, we need to create the plate
-      var plateName = $('#newNameInput').val().trim();
-      var plateConf = $('#plate-conf-select option:selected').val();
-      $.post('/process/sample_plating', {'plate_name': plateName, 'plate_configuration': plateConf}, function (data) {
-        that.plateId = data['plate_id'];
-        that.processId = data['process_id'];
-
-        // we can only instantiate the notes box when we have a process id
-        that.notes = new NotesBox(that.container.parent(),
-                                  '/process/sample_plating/notes',
-                                  that.processId);
-
-        $('#plateName').prop('pm-data-plate-id', that.plateId);
-        $('#plateName').prop('pm-data-process-id', that.processId);
-        // Once the plate has been created, we can disable the plate config select
-        $('#plate-conf-select').prop('disabled', true);
-        // The plate has been created, plate the sample
-        that.modifyWell(row, col, content);
-      })
-        .fail(function (jqXHR, textStatus, errorThrown) {
-          bootstrapAlert(jqXHR.responseText, 'danger');
-        });
-    } else {
-      // The plate already exists, simply plate the sample
-      that.modifyWell(row, col, content);
-    }
+    // The plate already exists, simply plate the sample
+    that.modifyWell(row, col, content);
   });
 
   // When the user right-clicks on a cell

--- a/labman/gui/templates/plate.html
+++ b/labman/gui/templates/plate.html
@@ -82,11 +82,18 @@
       $.get('/plate/' + plateId + '/', function(data) {
         $('#plateName').html(data['plate_name']);
         $('#plate-conf-select').val(data['plate_configuration'][0]);
+
+        // Load the plate map
+        var pv = new PlateViewer('plate-map-div', plateId, processId);
+        pv.notes = new NotesBox(pv.container.parent(),
+                                '/process/sample_plating/notes',
+                                processId);
+        pv.notes.setText(data.process_notes);
+
+        // Show the plate details div
+        $('#plateDetails').prop('hidden', false);
       });
-      // Load the plate map
-      var pv = new PlateViewer('plate-map-div', plateId, processId);
-      // Show the plate details div
-      $('#plateDetails').prop('hidden', false);
+
     }
 
     // Add the change callback to the plate configuration select

--- a/labman/gui/templates/plate.html
+++ b/labman/gui/templates/plate.html
@@ -76,6 +76,8 @@
       $('#plateName').prop('pm-data-plate-id', plateId);
       // Disable the plate config select
       $('#plate-conf-select').prop('disabled', true);
+      // Disable the plate create button
+      $('#createPlateBtn').prop('disabled', true);
       // Update the plate name in the interface
       $.get('/plate/' + plateId + '/', function(data) {
         $('#plateName').html(data['plate_name']);
@@ -83,6 +85,8 @@
       });
       // Load the plate map
       var pv = new PlateViewer('plate-map-div', plateId, processId);
+      // Show the plate details div
+      $('#plateDetails').prop('hidden', false);
     }
 
     // Add the change callback to the plate configuration select
@@ -101,7 +105,6 @@
 <label><h3>Plate '<span id='plateName'>New plate</span>'</h3></label>
 <!-- Add buttons next to the plate name -->
 <button class='btn btn-default' data-toggle='modal' data-target='#updatePlateName'><span class='glyphicon glyphicon-edit'></span> Change name</button>
-<a class='btn btn-success' href='/'>Save</a>
 <!-- <button class='btn btn-danger'><span class='glyphicon glyphicon-trash'></span> Delete</button> -->
 
 <!-- Plate configuration div -->
@@ -115,37 +118,42 @@
   </select>
 </div>
 
-<!-- Studies div -->
-<div>
-  <label><h4>Studies being plated</h4></label>
-  <button class='btn btn-success' data-toggle='modal' data-target='#addStudyModal'><span class='glyphicon glyphicon-plus'></span> Add study</button>
-  <div id='study-list'>
-  </div>
+<!--Only enable this after plate configuration has been selected-->
+<button id='createPlateBtn' class='btn btn-success' onclick='createPlate();' disabled>Create</button>
+
+<div id="plateDetails" hidden>
+    <!-- Studies div -->
+    <div>
+      <label><h4>Studies being plated</h4></label>
+      <button class='btn btn-success' data-toggle='modal' data-target='#addStudyModal'><span class='glyphicon glyphicon-plus'></span> Add study</button>
+      <div id='study-list'>
+      </div>
+    </div>
+
+    <!-- Plate map div -->
+    <h4>Plate map</h4>
+
+    <!-- Controls div -->
+    <div><h5>Controls description</h5>
+      <p>Press <kbd class='key'>ESC</kbd> to enter cell <i>selection mode</i></p>
+      <p>Press <kbd class='key'>ENTER</kbd> or double click a cell to enter <i>edit mode</i></p>
+      <p>To add new Control types, go to <a target='_blank' href="/sample/manage_controls">Admin > Manage control sample types</a></p>
+        <table>
+          {% for cd in controls_description %}
+            <tr>
+              <td>{{cd['external_id']}}:</td>
+              <td>{{cd['description']}}</td>
+            </tr>
+          {% end %}
+        </table>
+      </span>
+    </div>
+
+    <div id='plate-map-div' class='spreadsheet-container'></div>
+
+    <h4>Well comments</h4>
+    <div id='well-plate-comments' class="comment-box"></div>
 </div>
-
-<!-- Plate map div -->
-<h4>Plate map</h4>
-
-<!-- Controls div -->
-<div><h5>Controls description</h5>
-  <p>Press <kbd class='key'>ESC</kbd> to enter cell <i>selection mode</i></p>
-  <p>Press <kbd class='key'>ENTER</kbd> or double click a cell to enter <i>edit mode</i></p>
-  <p>To add new Control types, go to <a target='_blank' href="/sample/manage_controls">Admin > Manage control sample types</a></p>
-    <table>
-      {% for cd in controls_description %}
-        <tr>
-          <td>{{cd['external_id']}}:</td>
-          <td>{{cd['description']}}</td>
-        </tr>
-      {% end %}
-    </table>
-  </span>
-</div>
-
-<div id='plate-map-div' class='spreadsheet-container'></div>
-
-<h4>Well comments</h4>
-<div id='well-plate-comments' class="comment-box"></div>
 
 <!-- Modal to update the plate name -->
 <div class='modal fade' tabindex='-1' role='dialog' id='updatePlateName' data-keyboard="false" data-backdrop="static">

--- a/labman/gui/templates/plate_list.html
+++ b/labman/gui/templates/plate_list.html
@@ -101,11 +101,9 @@
           var deleteButton = '<a onclick="discardPlate(' + row[0] + ', this)" class="btn btn-danger btn-circle-small">' +
                                '<span class="glyphicon glyphicon-remove" data-toggle="tooltip" title="Remove plate"></span>' +
                              '</a> ';
-          var studiesList = '';
-          if (row[2] !== null) {
-              studiesList = row[2].join('<br />');
-          }
-          newData.push([chBox, row[0], row[1], studiesList, deleteButton]);
+          // row[0] = plate id, row[1] = external id, row[2] = list of names of
+          // studies associated with any sample on plate (may be empty list)
+          newData.push([chBox, row[0], row[1], row[2].join('<br />'), deleteButton]);
         }
         datatable.clear();
         datatable.rows.add(newData);

--- a/labman/gui/templates/plate_list.html
+++ b/labman/gui/templates/plate_list.html
@@ -101,7 +101,11 @@
           var deleteButton = '<a onclick="discardPlate(' + row[0] + ', this)" class="btn btn-danger btn-circle-small">' +
                                '<span class="glyphicon glyphicon-remove" data-toggle="tooltip" title="Remove plate"></span>' +
                              '</a> ';
-          newData.push([chBox, row[0], row[1], row[2].join('<br/>'), deleteButton]);
+          var studiesList = '';
+          if (row[2] !== null) {
+              studiesList = row[2].join('<br />');
+          }
+          newData.push([chBox, row[0], row[1], studiesList, deleteButton]);
         }
         datatable.clear();
         datatable.rows.add(newData);

--- a/labman/gui/test/test_plate.py
+++ b/labman/gui/test/test_plate.py
@@ -144,7 +144,7 @@ class TestPlateHandlers(TestHandlerBase):
         self.assertCountEqual(obs.keys(), ['data'])
         obs_data = obs['data']
         self.assertEqual(len(obs_data), 26)
-        self.assertEqual(obs_data[0], [1, 'EMP 16S V4 primer plate 1', None])
+        self.assertEqual(obs_data[0], [1, 'EMP 16S V4 primer plate 1', []])
 
         response = self.get('/plate_list?plate_type=%5B%22sample%22%5D')
         self.assertEqual(response.code, 200)


### PR DESCRIPTION
This PR was written by @AmandaBirmingham and me. Briefly:

- This PR addresses #272: The error was caused because the plate UI incorrectly allowed for the addition of multiple samples before the plate was created. The UI has now been modified to make the plate creation step a requirement before the grid is displayed.

- This also fixes a problem where listing plates without study identifiers would result in the page crashing or no plates being loaded.

- Fixes a problem with viewing an existing plate where 384 plates would now be fully displayed on screen.

- Fixes a problem where the notes would note be loaded when viewing an existing plate.

- This adds a placeholder for the *Notes* widget in the sample plating interface.

Animated GIF:

![copy-pasting](https://user-images.githubusercontent.com/375307/43442433-c43bfd2c-9452-11e8-8ad3-09f1ce9c23f6.gif)
