### PR TITLE
fix #315 : Correct name of key file attribute of ConfigurationManager in start-up script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,8 @@ install:
   # Deactivate the Qiita environment
   - source deactivate
   # Set the labman config file
-  - cp labman/db/support_files/test_config.cfg ~/.labman.cfg
+  - sed "s#CERTIFICATE_FILEPATH=#CERTIFICATE_FILEPATH=$PWD/support_files/server.crt#g" labman/db/support_files/test_config.cfg > ~/.labman.cfg.1
+  - sed "s#KEY_FILEPATH=#KEY_FILEPATH=$PWD/support_files/server.key#g" ~/.labman.cfg.1 > ~/.labman.cfg
   # Install labman
   - travis_retry conda create --yes -n labman python=$PYTHON_VERSION pip nose flake8 mock
   - source activate labman

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ script:
   - flake8 labman setup.py scripts/*
   - labman/db/tests/tester.py integration_tests
   - labman/db/tests/tester.py stress_tests --num_plates 2
-  - labman &
+  - labman start_webserver
   - LABMAN_PID=$!
   - sleep 5 # or 10?
   - kill $LABMAN_PID

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ script:
   - flake8 labman setup.py scripts/*
   - labman/db/tests/tester.py integration_tests
   - labman/db/tests/tester.py stress_tests --num_plates 2
-  - labman start_webserver
+  - labman start_webserver &
   - LABMAN_PID=$!
   - sleep 5 # or 10?
   - kill $LABMAN_PID

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,6 +46,10 @@ script:
   - flake8 labman setup.py scripts/*
   - labman/db/tests/tester.py integration_tests
   - labman/db/tests/tester.py stress_tests --num_plates 2
+  - labman &
+  - LABMAN_PID=$!
+  - sleep 5 # or 10?
+  - kill $LABMAN_PID
 addons:
   postgresql: "9.3"
 services:

--- a/README.md
+++ b/README.md
@@ -27,11 +27,15 @@ You can then install labman by simply running:
 pip install -e .
 ```
 
-Generate certificates for HTTPS using default values, we suggest changing them:
+Generate a certificate for HTTPS (note that the below command uses default values, 
+but of course we suggest changing them):
 
 ```bash
 mkdir -p support_files
-openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout support_files/server.key -out support_files/server.crt -subj "/C=US/ST=CA/L=LaJolla/O=/CN=localhost"
+openssl req -x509 -nodes -days 365 -newkey rsa:2048 \
+    -keyout support_files/server.key \
+    -out support_files/server.crt \
+    -subj "/C=US/ST=CA/L=LaJolla/O=/CN=localhost"
 ```
 
 Configure labman by running `labman config` and answer to the configuration questions:
@@ -41,8 +45,8 @@ Path to the configuration file [~/.labman.cfg]:
 Main configuration:
 Test environment [True]:
 Log directory [/tmp/]:
-Labman Certificate Filepath []:
-Labman Key Filepath []:
+Labman Certificate Filepath []: /PATH/TO/labman/support_files/server.crt
+Labman Key Filepath []: /PATH/TO/labman/support_files/server.key
 Postgres configuration:
 Postgres host [localhost]:
 Postgres port [5432]:

--- a/scripts/labman
+++ b/scripts/labman
@@ -40,7 +40,7 @@ def start_webserver(port):
 
     # Create the webserver
     ssl_options = {'certfile': labman_settings.certificate_filepath,
-                   'keyfile': labman_settings.keyfile}
+                   'keyfile': labman_settings.key_filepath}
     http_server = HTTPServer(Application(), ssl_options=ssl_options)
     try:
         http_server.listen(port)


### PR DESCRIPTION
With added text in readme and a travis change to test fix, per Antonio