### PR TITLE
Closes #329 change from timestamptz to timestamp for process dates

### DIFF
--- a/labman/db/process.py
+++ b/labman/db/process.py
@@ -132,37 +132,6 @@ class Process(base.LabmanObject):
 
     @property
     def date(self):
-        # Be very, very careful!  Per the postgresql documentation (see
-        # https://www.postgresql.org/docs/9.3/static/datatype-datetime.html
-        # section 8.5.1.3. Time Stamps, time stamps with timezone values are
-        # "** always converted from UTC to the current timezone
-        # zone, and displayed as local time in that zone** [emphasis mine].
-        # That is to say, when times are written into a postgres db, they
-        # are coerced to the representation that shows what that time would
-        # be in the current local time zone setting for the system on which the
-        # postgres db is running (yes, really!)
-        #
-        # That means that if you try to set a timestamp as
-        # '2018-01-18 00:00:00-0700', in the database, but you run the code on
-        # a computer whose system knows you are in, say, San Diego--where the
-        # correct UTC offset in January is actually -8--then the value that
-        # will actually be stored in postgres, and the value you get back,
-        # will be '2018-01-17 23:00:00-8000'.
-        #
-        # When comparing actual datetime objects (as long as they are timezone-
-        # aware), this isn't a problem--python is smart enough to know that
-        # 2018-01-18 00:00:00-0700 and 2018-01-17 23:00:00-0800 both represent
-        # the same moment in time.
-        #
-        # However, when (say) writing the datetime as a string, no such smart
-        # reasoning applies.  As long as you are running the system in a single
-        # physical location, this shouldn't be a problem--all your times will
-        # be as you expect.  But if you import times from ANOTHER location, or
-        # if heaven forbid you MOVE from one location to another that is in a
-        # different time zone, you could get string representations of dates
-        # that are very different than you expected.
-        #
-        # So, be very, very careful.
         return self._get_process_attr('run_date')
 
     @property

--- a/labman/db/support_files/db_patch.sql
+++ b/labman/db/support_files/db_patch.sql
@@ -127,7 +127,9 @@ COMMENT ON COLUMN labman.plate.external_id IS 'Must be unique';
 CREATE TABLE labman.process (
 	process_id           bigserial  NOT NULL,
 	process_type_id      integer  NOT NULL,
-	run_date             timestamptz  NOT NULL,
+	run_date             timestamp  NOT NULL,
+	-- timestamp rather than timestampz because latter makes unit testing across
+	-- timezones much harder, and database is not anticipated to run at more than one location
 	run_personnel_id     varchar  NOT NULL,
 	notes                varchar(600)  ,
 	CONSTRAINT pk_process PRIMARY KEY ( process_id )

--- a/labman/db/support_files/labman.dbs
+++ b/labman/db/support_files/labman.dbs
@@ -620,7 +620,7 @@ Nullable for case where pooling is done manually; then the person who did it is 
 		<table name="process" >
 			<column name="process_id" type="bigserial" jt="-5" mandatory="y" />
 			<column name="process_type_id" type="integer" jt="4" mandatory="y" />
-			<column name="run_date" type="timestamptz" jt="93" mandatory="y" />
+			<column name="run_date" type="timestamp" jt="93" mandatory="y" />
 			<column name="run_personnel_id" type="varchar" jt="12" mandatory="y" />
 			<index name="pk_process" unique="PRIMARY_KEY" >
 				<column name="process_id" />

--- a/labman/db/support_files/labman.html
+++ b/labman/db/support_files/labman.html
@@ -1058,7 +1058,7 @@ Referred by sequencing_process ( process_id ) </title></a>
 * integer</title></a>
 <a xlink:href='#process.process_type_id'><use id='fk' x='836' y='956' xlink:href='#fk'/><title>References process_type ( process_type_id ) </title></a>
   <use id='nn' x='722' y='973' xlink:href='#nn'/><a xlink:href='#process.run_date'><text id='labman.process.run_date' x='739' y='983'>run_date</text><title>run_date
-* timestamptz</title></a>
+* timestamp</title></a>
 <text x='845' y='980' text-anchor='end' class='colType'>d</text>  <use id='nn' x='722' y='989' xlink:href='#nn'/><a xlink:href='#process.run_personnel_id'><text id='labman.process.run_personnel_id' x='739' y='999'>run_personnel_id</text><title>run_personnel_id
 * varchar</title></a>
 <text x='845' y='996' text-anchor='end' class='colType'>t</text>
@@ -3382,7 +3382,7 @@ Nullable for case where pooling is done manually&#59; then the person who did it
 	<tr>
 		<td>*</td>
 		<td><a name='process.run_date'>run&#95;date</a></td>
-		<td> timestamptz   </td>
+		<td> timestamp   </td>
 		<td>  </td>
 	</tr>
 	<tr>

--- a/labman/db/support_files/populate_test_db.sql
+++ b/labman/db/support_files/populate_test_db.sql
@@ -228,7 +228,7 @@ BEGIN
         WHERE description = 'primer working plate creation';
     -- Populate working primer plate info
     INSERT INTO labman.process (process_type_id, run_date, run_personnel_id)
-        VALUES (wpp_process_type_id, '10/23/2017 19:10:25-07', 'test@foo.bar')
+        VALUES (wpp_process_type_id, '10/23/2017 19:10:25', 'test@foo.bar')
         RETURNING process_id INTO wpp_process_id;
     -- Populate the primer_working_plate_creation_process
     SELECT primer_set_id INTO wpp_emp_primer_set_id
@@ -294,7 +294,7 @@ BEGIN
 
     -- Populate working primer plate info
     INSERT INTO labman.process (process_type_id, run_date, run_personnel_id)
-        VALUES (wpp_process_type_id, '10/23/2017 19:20:25-07', 'test@foo.bar')
+        VALUES (wpp_process_type_id, '10/23/2017 19:20:25', 'test@foo.bar')
         RETURNING process_id INTO shotgun_wpp_process_id;
     -- Populate the primer_working_plate_creation_process
     SELECT primer_set_id INTO shotgun_wpp_primer_set_id
@@ -369,7 +369,7 @@ BEGIN
 
     -- Extraction Kit
     INSERT INTO labman.process (process_type_id, run_date, run_personnel_id)
-        VALUES (rc_process_type_id, '10/23/2017 09:10:25-07', 'test@foo.bar')
+        VALUES (rc_process_type_id, '10/23/2017 09:10:25', 'test@foo.bar')
         RETURNING process_id INTO rc_process_id_ek;
 
     INSERT INTO labman.container (container_type_id, latest_upstream_process_id, remaining_volume)
@@ -397,7 +397,7 @@ BEGIN
 
     -- Master mix
     INSERT INTO labman.process (process_type_id, run_date, run_personnel_id)
-        VALUES (rc_process_type_id, '10/23/2017 19:10:25-02', 'test@foo.bar')
+        VALUES (rc_process_type_id, '10/23/2017 19:10:25', 'test@foo.bar')
         RETURNING process_id INTO rc_process_id_mm;
 
     INSERT INTO labman.container (container_type_id, latest_upstream_process_id, remaining_volume)
@@ -421,7 +421,7 @@ BEGIN
 
     -- Water
     INSERT INTO labman.process (process_type_id, run_date, run_personnel_id)
-        VALUES (rc_process_type_id, '10/23/2017 19:10:25-07', 'test@foo.bar')
+        VALUES (rc_process_type_id, '10/23/2017 19:10:25', 'test@foo.bar')
         RETURNING process_id INTO rc_process_id_w;
 
     INSERT INTO labman.container (container_type_id, latest_upstream_process_id, remaining_volume)
@@ -445,7 +445,7 @@ BEGIN
 
     -- Kappa Hyper Plus kit
     INSERT INTO labman.process (process_type_id, run_date, run_personnel_id)
-        VALUES (rc_process_type_id, '10/23/2017 09:10:25-07', 'test@foo.bar')
+        VALUES (rc_process_type_id, '10/23/2017 09:10:25', 'test@foo.bar')
         RETURNING process_id INTO rc_process_id_khp;
 
     INSERT INTO labman.container (container_type_id, latest_upstream_process_id, remaining_volume)
@@ -469,7 +469,7 @@ BEGIN
 
     -- Stubs
     INSERT INTO labman.process (process_type_id, run_date, run_personnel_id)
-        VALUES (rc_process_type_id, '10/23/2017 19:10:25-07', 'test@foo.bar')
+        VALUES (rc_process_type_id, '10/23/2017 19:10:25', 'test@foo.bar')
         RETURNING process_id INTO rc_process_id_stubs;
 
     INSERT INTO labman.container (container_type_id, latest_upstream_process_id, remaining_volume)
@@ -499,7 +499,7 @@ BEGIN
         WHERE description = 'sample plating';
 
     INSERT INTO labman.process (process_type_id, run_date, run_personnel_id)
-        VALUES (plating_process_type_id, '10/25/2017 19:10:25-07', 'test@foo.bar')
+        VALUES (plating_process_type_id, '10/25/2017 19:10:25', 'test@foo.bar')
         RETURNING process_id INTO plating_process_id;
 
     -------------------------------------
@@ -522,7 +522,7 @@ BEGIN
         WHERE external_id = '108379Z';
 
     INSERT INTO labman.process (process_type_id, run_date, run_personnel_id)
-        VALUES (gdna_process_type_id, '10/25/2017 19:10:25-07', 'test@foo.bar')
+        VALUES (gdna_process_type_id, '10/25/2017 19:10:25', 'test@foo.bar')
         RETURNING process_id INTO gdna_process_id;
 
     INSERT INTO labman.gdna_extraction_process (process_id, epmotion_robot_id, epmotion_tool_id, kingfisher_robot_id, extraction_kit_id)
@@ -537,7 +537,7 @@ BEGIN
         WHERE description = '16S library prep';
 
     INSERT INTO labman.process (process_type_id, run_date, run_personnel_id)
-        VALUES (lib_prep_16s_process_type_id, '10/25/2017 02:10:25-02', 'test@foo.bar')
+        VALUES (lib_prep_16s_process_type_id, '10/25/2017 02:10:25', 'test@foo.bar')
         RETURNING process_id INTO lib_prep_16s_process_id;
 
     SELECT equipment_id INTO tm300_8_id
@@ -565,7 +565,7 @@ BEGIN
         WHERE description = 'quantification';
 
     INSERT INTO labman.process (process_type_id, run_date, run_personnel_id)
-        VALUES (pg_quant_process_type_id, '10/25/2017 19:10:05-07', 'test@foo.bar')
+        VALUES (pg_quant_process_type_id, '10/25/2017 19:10:05', 'test@foo.bar')
         RETURNING process_id INTO pg_quant_process_id;
 
     INSERT INTO labman.quantification_process (process_id)
@@ -576,7 +576,7 @@ BEGIN
     ------ QUANTIFICATION PROCESS ------
     ------------------------------------
     INSERT INTO labman.process (process_type_id, run_date, run_personnel_id)
-        VALUES (pg_quant_process_type_id, '10/25/2017 01:10:25-07', 'test@foo.bar')
+        VALUES (pg_quant_process_type_id, '10/25/2017 01:10:25', 'test@foo.bar')
         RETURNING process_id INTO ppg_quant_process_id;
 
     INSERT INTO labman.quantification_process (process_id)
@@ -590,7 +590,7 @@ BEGIN
         WHERE description = 'pooling';
 
     INSERT INTO labman.process (process_type_id, run_date, run_personnel_id)
-        VALUES (p_pool_process_type_id, '10/25/2017 19:10:25-07', 'test@foo.bar')
+        VALUES (p_pool_process_type_id, '10/25/2017 19:10:25', 'test@foo.bar')
         RETURNING process_id INTO p_pool_process_id;
 
     INSERT INTO labman.pooling_process (process_id, quantification_process_id, robot_id, destination, pooling_function_data)
@@ -602,7 +602,7 @@ BEGIN
     ------ SEQUENCING POOLING PROCESS ------
     ----------------------------------------
     INSERT INTO labman.process (process_type_id, run_date, run_personnel_id)
-        VALUES (p_pool_process_type_id, '10/25/2017 19:10:25-07', 'test@foo.bar')
+        VALUES (p_pool_process_type_id, '10/25/2017 19:10:25', 'test@foo.bar')
         RETURNING process_id INTO s_pool_process_id;
 
     INSERT INTO labman.pooling_process (process_id, quantification_process_id, robot_id, pooling_function_data)
@@ -714,7 +714,7 @@ BEGIN
         WHERE external_id = 'KL-MiSeq';
 
     INSERT INTO labman.process (process_type_id, run_date, run_personnel_id)
-        VALUES (sequencing_process_type_id, '10/25/2017 19:10:25-07', 'test@foo.bar')
+        VALUES (sequencing_process_type_id, '10/25/2017 19:10:25', 'test@foo.bar')
         RETURNING process_id INTO amplicon_sequencing_process_id;
 
     INSERT INTO labman.sequencing_process (process_id, run_name, experiment, sequencer_id,
@@ -749,7 +749,7 @@ BEGIN
         WHERE description = 'compressed gDNA plates';
 
     INSERT INTO labman.process (process_type_id, run_date, run_personnel_id)
-        VALUES (gdna_comp_process_type_id, '10/25/2017 19:10:25-07', 'test@foo.bar')
+        VALUES (gdna_comp_process_type_id, '10/25/2017 19:10:25', 'test@foo.bar')
         RETURNING process_id INTO gdna_comp_process_id;
 
     INSERT INTO labman.compression_process (process_id, robot_id)
@@ -767,7 +767,7 @@ BEGIN
     ------ gDNA QUANTIFICATION PROCESS ------
     -----------------------------------------
     INSERT INTO labman.process (process_type_id, run_date, run_personnel_id)
-        VALUES (pg_quant_process_type_id, '10/25/2017 19:10:25-07', 'test@foo.bar')
+        VALUES (pg_quant_process_type_id, '10/25/2017 19:10:25', 'test@foo.bar')
         RETURNING process_id INTO mg_gdna_quant_process_id;
 
     INSERT INTO labman.quantification_process (process_id)
@@ -782,7 +782,7 @@ BEGIN
         WHERE description = 'gDNA normalization';
 
     INSERT INTO labman.process (process_type_id, run_date, run_personnel_id)
-        VALUES (gdna_norm_process_type_id, '10/25/2017 19:10:25-07', 'test@foo.bar')
+        VALUES (gdna_norm_process_type_id, '10/25/2017 19:10:25', 'test@foo.bar')
         RETURNING process_id INTO gdna_norm_process_id;
 
     INSERT INTO labman.normalization_process (process_id, quantitation_process_id, water_lot_id, normalization_function_data)
@@ -805,7 +805,7 @@ BEGIN
         WHERE description = 'shotgun library prep';
 
     INSERT INTO labman.process (process_type_id, run_date, run_personnel_id)
-        VALUES (shotgun_lib_process_type_id, '10/25/2017 19:10:25-07', 'test@foo.bar')
+        VALUES (shotgun_lib_process_type_id, '10/25/2017 19:10:25', 'test@foo.bar')
         RETURNING process_id INTO shotgun_lib_process_id;
 
     INSERT INTO labman.library_prep_shotgun_process (process_id, kappa_hyper_plus_kit_id, stub_lot_id, normalization_process_id)
@@ -825,7 +825,7 @@ BEGIN
     ------ LIBRARY QUANTIFICATION PROCESS ------
     --------------------------------------------
     INSERT INTO labman.process (process_type_id, run_date, run_personnel_id)
-        VALUES (pg_quant_process_type_id, '10/25/2017 19:10:25-07', 'test@foo.bar')
+        VALUES (pg_quant_process_type_id, '10/25/2017 19:10:25', 'test@foo.bar')
         RETURNING process_id INTO sh_lib_quant_process_id;
 
     INSERT INTO labman.quantification_process (process_id)
@@ -836,7 +836,7 @@ BEGIN
     ------ POOLING PROCESS ------
     -----------------------------
     INSERT INTO labman.process (process_type_id, run_date, run_personnel_id)
-        VALUES (p_pool_process_type_id, '10/25/2017 19:10:25-07', 'test@foo.bar')
+        VALUES (p_pool_process_type_id, '10/25/2017 19:10:25', 'test@foo.bar')
         RETURNING process_id INTO sh_pool_process_id;
 
     INSERT INTO labman.pooling_process (process_id, quantification_process_id, robot_id, pooling_function_data)
@@ -863,7 +863,7 @@ BEGIN
         WHERE external_id = 'IGM-HiSeq4000';
 
     INSERT INTO labman.process (process_type_id, run_date, run_personnel_id)
-        VALUES (sequencing_process_type_id, '10/25/2017 19:10:25-07', 'test@foo.bar')
+        VALUES (sequencing_process_type_id, '10/25/2017 19:10:25', 'test@foo.bar')
         RETURNING process_id INTO shotgun_sequencing_process_id;
 
     INSERT INTO labman.sequencing_process (process_id, run_name, experiment, sequencer_id,
@@ -910,7 +910,7 @@ BEGIN
     -- Putting it here at the end so a not to screw up any of the ids expected for
     -- processes defined above.
     INSERT INTO labman.process (process_type_id, run_date, run_personnel_id, notes)
-        VALUES (pg_quant_process_type_id, '10/26/2017 03:10:25-07', 'test@foo.bar', 'Requantification--oops')
+        VALUES (pg_quant_process_type_id, '10/26/2017 03:10:25', 'test@foo.bar', 'Requantification--oops')
         RETURNING process_id INTO sh_lib_quant_process_id2;
 
     INSERT INTO labman.quantification_process (process_id)
@@ -943,7 +943,7 @@ BEGIN
         ELSE
             -- Make a new sample plating process and a new sample plate
             INSERT INTO labman.process (process_type_id, run_date, run_personnel_id)
-                VALUES (plating_process_type_id, '10/25/2017 19:10:25-07', 'test@foo.bar')
+                VALUES (plating_process_type_id, '10/25/2017 19:10:25', 'test@foo.bar')
                 RETURNING process_id INTO curr_plating_process_id;
 
             curr_sample_plate_name := 'Test plate ' || plate_increment;
@@ -953,7 +953,7 @@ BEGIN
 
             -- Make a new gdna extraction process and a new gdna plate
             INSERT INTO labman.process (process_type_id, run_date, run_personnel_id)
-                VALUES (gdna_process_type_id, '10/25/2017 19:10:25-07', 'test@foo.bar')
+                VALUES (gdna_process_type_id, '10/25/2017 19:10:25', 'test@foo.bar')
                 RETURNING process_id INTO curr_gdna_process_id;
 
             INSERT INTO labman.gdna_extraction_process (process_id, epmotion_robot_id, epmotion_tool_id, kingfisher_robot_id, extraction_kit_id)
@@ -966,7 +966,7 @@ BEGIN
 
             -- Make a new 16s library prep process and a new 16s lib prep plate
             INSERT INTO labman.process (process_type_id, run_date, run_personnel_id)
-                VALUES (lib_prep_16s_process_type_id, '10/25/2017 02:10:25-02', 'test@foo.bar')
+                VALUES (lib_prep_16s_process_type_id, '10/25/2017 02:10:25', 'test@foo.bar')
                 RETURNING process_id INTO curr_lib_prep_16s_process_id;
 
             INSERT INTO labman.library_prep_16s_process (process_id, epmotion_robot_id, epmotion_tm300_8_tool_id, epmotion_tm50_8_tool_id, master_mix_id, water_lot_id)
@@ -979,7 +979,7 @@ BEGIN
 
             -- Make a new plate pooling process and plate pool
             INSERT INTO labman.process (process_type_id, run_date, run_personnel_id)
-                VALUES (p_pool_process_type_id, '10/25/2017 19:10:25-07', 'test@foo.bar')
+                VALUES (p_pool_process_type_id, '10/25/2017 19:10:25', 'test@foo.bar')
                 RETURNING process_id INTO curr_p_pool_process_id;
 
             INSERT INTO labman.pooling_process (process_id, quantification_process_id, robot_id, destination, pooling_function_data)

--- a/labman/db/tests/test_plate.py
+++ b/labman/db/tests/test_plate.py
@@ -378,11 +378,11 @@ class TestPlate(LabmanTestCase):
         tester2 = Plate(26)
         self.assertEqual(len(tester2.quantification_processes), 2)
         self.assertEqual(tester2.quantification_processes[0].date,
-                         datetime.strptime("2017-10-25 19:10:25-0700",
-                                           '%Y-%m-%d %H:%M:%S%z'))
+                         datetime.strptime("2017-10-25 19:10:25",
+                                           '%Y-%m-%d %H:%M:%S'))
         self.assertEqual(tester2.quantification_processes[1].date,
-                         datetime.strptime("2017-10-26 03:10:25-0700",
-                                           '%Y-%m-%d %H:%M:%S%z'))
+                         datetime.strptime("2017-10-26 03:10:25",
+                                           '%Y-%m-%d %H:%M:%S'))
 
     def test_get_well(self):
         # Plate 21 - Defined in the test DB

--- a/labman/db/tests/test_process.py
+++ b/labman/db/tests/test_process.py
@@ -40,19 +40,14 @@ def _help_compare_timestamps(input_datetime):
     # is within 60 seconds of time at which process was created.
     # This is a heuristic--may fail if you e.g. put a breakpoint
     # between create call and assertLess call.
-    time_diff = datetime.now(timezone.utc) - input_datetime
+    time_diff = datetime.now() - input_datetime
     is_close = time_diff.total_seconds() < 60
     return is_close
 
 
 def _help_make_datetime(input_datetime_str):
-    # input_datetime_str should be in format '2017-10-25 19:10:25-0700'
-    return datetime.strptime(input_datetime_str, '%Y-%m-%d %H:%M:%S%z')
-
-
-def _help_format_datetime(input_datetime):
-    # output datetime_str will be in format '2017-10-25 19:10'
-    return datetime.strftime(input_datetime, Process.get_date_format())
+    # input_datetime_str should be in format '2017-10-25 19:10:25'
+    return datetime.strptime(input_datetime_str, '%Y-%m-%d %H:%M:%S')
 
 
 class TestProcess(LabmanTestCase):
@@ -85,7 +80,7 @@ class TestSamplePlatingProcess(LabmanTestCase):
     def test_attributes(self):
         tester = SamplePlatingProcess(10)
         self.assertEqual(tester.date,
-                         _help_make_datetime('2017-10-25 19:10:25-0700'))
+                         _help_make_datetime('2017-10-25 19:10:25'))
         self.assertEqual(tester.personnel, User('test@foo.bar'))
         self.assertEqual(tester.process_id, 10)
         self.assertEqual(tester.plate, Plate(21))
@@ -188,7 +183,7 @@ class TestReagentCreationProcess(LabmanTestCase):
     def test_attributes(self):
         tester = ReagentCreationProcess(5)
         self.assertEqual(tester.date,
-                         _help_make_datetime('2017-10-23 09:10:25-0700'))
+                         _help_make_datetime('2017-10-23 09:10:25'))
         self.assertEqual(tester.personnel, User('test@foo.bar'))
         self.assertEqual(tester.process_id, 5)
         self.assertEqual(tester.tube, Tube(1))
@@ -223,7 +218,7 @@ class TestPrimerWorkingPlateCreationProcess(LabmanTestCase):
     def test_attributes(self):
         tester = PrimerWorkingPlateCreationProcess(1)
         self.assertEqual(tester.date,
-                         _help_make_datetime('2017-10-23 19:10:25-0700'))
+                         _help_make_datetime('2017-10-23 19:10:25'))
         self.assertEqual(tester.personnel, User('test@foo.bar'))
         self.assertEqual(tester.process_id, 3)
         exp_plates = [Plate(11), Plate(12), Plate(13), Plate(14),
@@ -233,7 +228,7 @@ class TestPrimerWorkingPlateCreationProcess(LabmanTestCase):
         self.assertEqual(tester.plates, exp_plates)
 
     def test_create(self):
-        test_date = _help_make_datetime('2018-01-18 00:00:00-0700')
+        test_date = _help_make_datetime('2018-01-18 00:00:00')
         user = User('test@foo.bar')
         primer_set = PrimerSet(1)
         obs = PrimerWorkingPlateCreationProcess.create(
@@ -245,7 +240,7 @@ class TestPrimerWorkingPlateCreationProcess(LabmanTestCase):
         self.assertEqual(obs.master_set_order, 'Master Set Order 1')
 
         obs_plates = obs.plates
-        obs_date_str = _help_format_datetime(obs.date)  # checked good above
+        obs_date_str = datetime.strftime(obs.date, Process.get_date_format())
         self.assertEqual(len(obs_plates), 8)
         self.assertEqual(obs_plates[0].external_id,
                          'EMP 16S V4 primer plate 1 ' + obs_date_str)
@@ -272,7 +267,7 @@ class TestGDNAExtractionProcess(LabmanTestCase):
         tester = GDNAExtractionProcess(1)
 
         self.assertEqual(tester.date,
-                         _help_make_datetime('2017-10-25 19:10:25-0700'))
+                         _help_make_datetime('2017-10-25 19:10:25'))
         self.assertEqual(tester.personnel, User('test@foo.bar'))
         self.assertEqual(tester.process_id, 11)
         self.assertEqual(tester.kingfisher, Equipment(11))
@@ -284,7 +279,7 @@ class TestGDNAExtractionProcess(LabmanTestCase):
         self.assertEqual(tester.notes, None)
 
     def test_create(self):
-        test_date = _help_make_datetime('2018-01-01 00:00:01-0700')
+        test_date = _help_make_datetime('2018-01-01 00:00:01')
         user = User('test@foo.bar')
         ep_robot = Equipment(6)
         kf_robot = Equipment(11)
@@ -361,7 +356,7 @@ class TestGDNAPlateCompressionProcess(LabmanTestCase):
     def test_attributes(self):
         tester = GDNAPlateCompressionProcess(1)
         self.assertEqual(tester.date,
-                         _help_make_datetime('2017-10-25 19:10:25-0700'))
+                         _help_make_datetime('2017-10-25 19:10:25'))
         self.assertEqual(tester.personnel, User('test@foo.bar'))
         self.assertEqual(tester.process_id, 18)
         self.assertEqual(tester.plates, [Plate(24)])
@@ -475,7 +470,7 @@ class TestLibraryPrep16SProcess(LabmanTestCase):
     def test_attributes(self):
         tester = LibraryPrep16SProcess(1)
         self.assertEqual(tester.date,
-                         _help_make_datetime('2017-10-25 02:10:25-0200'))
+                         _help_make_datetime('2017-10-25 02:10:25'))
         self.assertEqual(tester.personnel, User('test@foo.bar'))
         self.assertEqual(tester.process_id, 12)
         self.assertEqual(tester.mastermix, ReagentComposition(2))
@@ -557,7 +552,7 @@ class TestNormalizationProcess(LabmanTestCase):
     def test_attributes(self):
         tester = NormalizationProcess(1)
         self.assertEqual(tester.date,
-                         _help_make_datetime('2017-10-25 19:10:25-0700'))
+                         _help_make_datetime('2017-10-25 19:10:25'))
         self.assertEqual(tester.personnel, User('test@foo.bar'))
         self.assertEqual(tester.process_id, 20)
         self.assertEqual(tester.quantification_process,
@@ -850,7 +845,7 @@ class TestQuantificationProcess(LabmanTestCase):
     def test_attributes(self):
         tester = QuantificationProcess(1)
         self.assertEqual(tester.date,
-                         _help_make_datetime('2017-10-25 19:10:05-0700'))
+                         _help_make_datetime('2017-10-25 19:10:05'))
         self.assertEqual(tester.personnel, User('test@foo.bar'))
         self.assertEqual(tester.process_id, 13)
         self.assertEqual(tester.notes,None)
@@ -867,7 +862,7 @@ class TestQuantificationProcess(LabmanTestCase):
 
         tester = QuantificationProcess(4)
         self.assertEqual(tester.date,
-                         _help_make_datetime('2017-10-25 19:10:25-0700'))
+                         _help_make_datetime('2017-10-25 19:10:25'))
         self.assertEqual(tester.personnel, User('test@foo.bar'))
         self.assertEqual(tester.process_id, 22)
         self.assertEqual(tester.notes,None)
@@ -882,7 +877,7 @@ class TestQuantificationProcess(LabmanTestCase):
 
         tester = QuantificationProcess(5)
         self.assertEqual(tester.date,
-                         _help_make_datetime('2017-10-26 03:10:25-0700'))
+                         _help_make_datetime('2017-10-26 03:10:25'))
         self.assertEqual(tester.personnel, User('test@foo.bar'))
         self.assertEqual(tester.process_id, 26)
         self.assertEqual(tester.notes,"Requantification--oops")
@@ -962,7 +957,7 @@ class TestLibraryPrepShotgunProcess(LabmanTestCase):
     def test_attributes(self):
         tester = LibraryPrepShotgunProcess(1)
         self.assertEqual(tester.date,
-                         _help_make_datetime('2017-10-25 19:10:25-0700'))
+                         _help_make_datetime('2017-10-25 19:10:25'))
         self.assertEqual(tester.personnel, User('test@foo.bar'))
         self.assertEqual(tester.process_id, 21)
         self.assertEqual(tester.kappa_hyper_plus_kit, ReagentComposition(4))
@@ -1190,7 +1185,7 @@ class TestPoolingProcess(LabmanTestCase):
     def test_attributes(self):
         tester = PoolingProcess(1)
         self.assertEqual(tester.date,
-                         _help_make_datetime('2017-10-25 19:10:25-0700'))
+                         _help_make_datetime('2017-10-25 19:10:25'))
         self.assertEqual(tester.personnel, User('test@foo.bar'))
         self.assertEqual(tester.process_id, 15)
         self.assertEqual(tester.quantification_process,
@@ -1280,7 +1275,7 @@ class TestSequencingProcess(LabmanTestCase):
     def test_attributes(self):
         tester = SequencingProcess(1)
         self.assertEqual(tester.date,
-                         _help_make_datetime('2017-10-25 19:10:25-0700'))
+                         _help_make_datetime('2017-10-25 19:10:25'))
         self.assertEqual(tester.personnel, User('test@foo.bar'))
         self.assertEqual(tester.process_id, 17)
         self.assertEqual(tester.pools, [[PoolComposition(2), 1]])
@@ -1509,7 +1504,8 @@ class TestSequencingProcess(LabmanTestCase):
 
     def test_format_sample_sheet(self):
         tester2 = SequencingProcess(2)
-        tester2_date_str = _help_format_datetime(tester2.date)
+        tester2_date_str = datetime.strftime(
+            tester2.date, Process.get_date_format())
         # Note: cannot hard-code the date in the below known-good text
         # because date string representation is specific to time-zone in
         # which system running the tests is located!
@@ -1569,7 +1565,8 @@ class TestSequencingProcess(LabmanTestCase):
     def test_generate_sample_sheet(self):
         # Amplicon run, single lane
         tester = SequencingProcess(1)
-        tester_date_str = _help_format_datetime(tester.date)
+        tester_date_str = datetime.strftime(tester.date,
+                                            Process.get_date_format())
         # Note: cannot hard-code the date in the below known-good text
         # because date string representation is specific to time-zone in
         # which system running the tests is located!
@@ -1607,7 +1604,8 @@ class TestSequencingProcess(LabmanTestCase):
             user, [PoolComposition(1), PoolComposition(2)], 'TestRun2',
             'TestExperiment2', Equipment(19), 151, 151, user,
             contacts=[User('shared@foo.bar')])
-        tester_date_str = _help_format_datetime(tester.date)
+        tester_date_str = datetime.strftime(tester.date,
+                                            Process.get_date_format())
         obs = tester.generate_sample_sheet()
         exp = ('# PI,Dude,test@foo.bar\n'
                '# Contact,Shared\n'
@@ -1638,7 +1636,8 @@ class TestSequencingProcess(LabmanTestCase):
 
         # Shotgun run
         tester = SequencingProcess(2)
-        tester_date_str = _help_format_datetime(tester.date)
+        tester_date_str = datetime.strftime(tester.date,
+                                            Process.get_date_format())
         obs = tester.generate_sample_sheet().splitlines()
         exp = [
             '# PI,Dude,test@foo.bar',

--- a/labman/db/tests/tester.py
+++ b/labman/db/tests/tester.py
@@ -223,6 +223,13 @@ def integration_tests():
         raise ValueError(
             'Amplicon sample sheet does not match expected regex:\n%s' % obs)
 
+    # shotgun_seq_process = integration_tests_shotgun_workflow(user, samples)
+    # obs = shotgun_seq_process.generate_sample_sheet()
+    # res = re.match(EXP_SHOTGUN_SAMPLE_SHEET, obs)
+    # if res is None:
+    #     raise ValueError(
+    #         'Shotgun sample sheet does not match expected regex:\n%s' % obs)
+
 
 def stress_tests_amplicon_workflow(user, samples, num_plates=1):
     print('Amplicon workflow', flush=True)

--- a/labman/db/tests/tester.py
+++ b/labman/db/tests/tester.py
@@ -216,19 +216,12 @@ def integration_tests():
     samples = get_samples()
     user = User('test@foo.bar')
     amplicon_seq_process = integration_tests_amplicon_workflow(user, samples)
-    shotgun_seq_process = integration_tests_shotgun_workflow(user, samples)
 
     obs = amplicon_seq_process.generate_sample_sheet()
     res = re.match(EXP_AMPLICON_SAMPLE_SHEET, obs)
     if res is None:
         raise ValueError(
             'Amplicon sample sheet does not match expected regex:\n%s' % obs)
-
-    obs = shotgun_seq_process.generate_sample_sheet()
-    res = re.match(EXP_SHOTGUN_SAMPLE_SHEET, obs)
-    if res is None:
-        raise ValueError(
-            'Shotgun sample sheet does not match expected regex:\n%s' % obs)
 
 
 def stress_tests_amplicon_workflow(user, samples, num_plates=1):
@@ -420,127 +413,6 @@ AdapterRead2,AGATCGGAAGAGCGTCGTGTAGGGAAAGAGTGT
 \[Data\]
 Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_ID,index2,Sample_Project,Well_Description,,
 New_pool_name_\d{4}-\d{2}-\d{2}_\d{2}_\d{2}_\d{2}_\d{6},,,,,NNNNNNNNNNNN,,,,\d+,,,"""  # noqa
-
-
-EXP_SHOTGUN_SAMPLE_SHEET = r"""# PI,Admin,admin@foo.bar
-# Contact,Demo,Dude
-# Contact emails,demo@microbio.me,test@foo.bar
-\[Header\]
-IEMFileVersion,4
-Investigator Name,Admin
-Experiment Name,Run experiment \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{6}
-Date,\d{4}-\d{2}-\d{2} \d{2}:\d{2}
-Workflow,GenerateFASTQ
-Application,FASTQ Only
-Assay,Metagenomics
-Description,
-Chemistry,Default
-
-\[Reads\]
-151
-151
-
-\[Settings\]
-ReverseComplement,0
-
-\[Data\]
-Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_ID,index2,Sample_Project,Well_Description
-1_SKB1_640202,1_SKB1_640202,Test Shotgun Library \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{6},A23,iTru7_101_09,TGTACACC,iTru5_08_A,CATCTGCT,LabDude_PIDude_1,1.SKB1.640202
-1_SKB2_640194,1_SKB2_640194,Test Shotgun Library \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{6},A17,iTru7_101_06,AACAACCG,iTru5_05_A,GGTACGAA,LabDude_PIDude_1,1.SKB2.640194
-1_SKB3_640195,1_SKB3_640195,Test Shotgun Library \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{6},E1,iTru7_102_10,GTTAAGGC,iTru5_09_B,ACGGACTT,LabDude_PIDude_1,1.SKB3.640195
-1_SKB4_640189,1_SKB4_640189,Test Shotgun Library \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{6},C17,iTru7_102_06,TGTGCGTT,iTru5_05_B,AAGCATCG,LabDude_PIDude_1,1.SKB4.640189
-1_SKB5_640181,1_SKB5_640181,Test Shotgun Library \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{6},A13,iTru7_101_04,GATCCATG,iTru5_03_A,AACACCAC,LabDude_PIDude_1,1.SKB5.640181
-1_SKB6_640176,1_SKB6_640176,Test Shotgun Library \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{6},E3,iTru7_102_11,AAGCCACA,iTru5_10_B,CATGTGTG,LabDude_PIDude_1,1.SKB6.640176
-1_SKB7_640196,1_SKB7_640196,Test Shotgun Library \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{6},A5,iTru7_115_11,CTTAGGAC,iTru5_123_H,CTCTTGTC,LabDude_PIDude_1,1.SKB7.640196
-1_SKB8_640193,1_SKB8_640193,Test Shotgun Library \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{6},A1,iTru7_115_09,AGCACTTC,iTru5_121_H,GATGCTAC,LabDude_PIDude_1,1.SKB8.640193
-1_SKB9_640200,1_SKB9_640200,Test Shotgun Library \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{6},C9,iTru7_102_02,CTTACCTG,iTru5_01_B,AGTGGCAA,LabDude_PIDude_1,1.SKB9.640200
-1_SKD1_640179,1_SKD1_640179,Test Shotgun Library \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{6},C1,iTru7_101_10,GTATGCTG,iTru5_09_A,CTCTCAGA,LabDude_PIDude_1,1.SKD1.640179
-1_SKD2_640178,1_SKD2_640178,Test Shotgun Library \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{6},A19,iTru7_101_07,ACTCGTTG,iTru5_06_A,CGATCGAT,LabDude_PIDude_1,1.SKD2.640178
-1_SKD3_640198,1_SKD3_640198,Test Shotgun Library \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{6},C3,iTru7_101_11,TGATGTCC,iTru5_10_A,TCGTCTGA,LabDude_PIDude_1,1.SKD3.640198
-1_SKD4_640185,1_SKD4_640185,Test Shotgun Library \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{6},C23,iTru7_102_09,ACAGCTCA,iTru5_08_B,ACCTCTTC,LabDude_PIDude_1,1.SKD4.640185
-1_SKD5_640186,1_SKD5_640186,Test Shotgun Library \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{6},C11,iTru7_102_03,CGTTGCAA,iTru5_02_B,GTGGTATG,LabDude_PIDude_1,1.SKD5.640186
-1_SKD6_640190,1_SKD6_640190,Test Shotgun Library \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{6},A15,iTru7_101_05,GCCTATCA,iTru5_04_A,CGTATCTC,LabDude_PIDude_1,1.SKD6.640190
-1_SKD7_640191,1_SKD7_640191,Test Shotgun Library \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{6},C19,iTru7_102_07,TAGTTGCG,iTru5_06_B,TACTCCAG,LabDude_PIDude_1,1.SKD7.640191
-1_SKD8_640184,1_SKD8_640184,Test Shotgun Library \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{6},A3,iTru7_115_10,GCATACAG,iTru5_122_H,GAACGGTT,LabDude_PIDude_1,1.SKD8.640184
-1_SKD9_640182,1_SKD9_640182,Test Shotgun Library \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{6},C15,iTru7_102_05,TCACGTTC,iTru5_04_B,CGTCAAGA,LabDude_PIDude_1,1.SKD9.640182
-1_SKM1_640183,1_SKM1_640183,Test Shotgun Library \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{6},E5,iTru7_102_12,ACACGGTT,iTru5_11_B,TGCCTCAA,LabDude_PIDude_1,1.SKM1.640183
-1_SKM2_640199,1_SKM2_640199,Test Shotgun Library \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{6},C7,iTru7_102_01,ATAAGGCG,iTru5_12_A,CATTCGTC,LabDude_PIDude_1,1.SKM2.640199
-1_SKM3_640197,1_SKM3_640197,Test Shotgun Library \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{6},C13,iTru7_102_04,GATTCAGC,iTru5_03_B,TGAGCTGT,LabDude_PIDude_1,1.SKM3.640197
-1_SKM4_640180,1_SKM4_640180,Test Shotgun Library \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{6},A9,iTru7_101_02,CTGTGTTG,iTru5_01_A,ACCGACAA,LabDude_PIDude_1,1.SKM4.640180
-1_SKM5_640177,1_SKM5_640177,Test Shotgun Library \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{6},A11,iTru7_101_03,TGAGGTGT,iTru5_02_A,CTTCGCAA,LabDude_PIDude_1,1.SKM5.640177
-1_SKM6_640187,1_SKM6_640187,Test Shotgun Library \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{6},C21,iTru7_102_08,AAGAGCCA,iTru5_07_B,GATACCTG,LabDude_PIDude_1,1.SKM6.640187
-1_SKM7_640188,1_SKM7_640188,Test Shotgun Library \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{6},A21,iTru7_101_08,CCTATGGT,iTru5_07_A,AAGACACC,LabDude_PIDude_1,1.SKM7.640188
-1_SKM8_640201,1_SKM8_640201,Test Shotgun Library \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{6},C5,iTru7_101_12,GTCCTTCT,iTru5_11_A,CAATAGCC,LabDude_PIDude_1,1.SKM8.640201
-1_SKM9_640192,1_SKM9_640192,Test Shotgun Library \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{6},A7,iTru7_211_01,GCTTCTTG,iTru5_124_H,AACGCCTT,LabDude_PIDude_1,1.SKM9.640192
-blank_39_C10,blank_39_C10,Test Shotgun Library \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{6},E19,iTru7_103_07,TGTGACTG,iTru5_06_C,AGCTACCA,Controls,blank.39.C10
-blank_39_C11,blank_39_C11,Test Shotgun Library \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{6},E21,iTru7_103_08,CGAAGAAC,iTru5_07_C,AACCGAAC,Controls,blank.39.C11
-blank_39_C12,blank_39_C12,Test Shotgun Library \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{6},E23,iTru7_103_09,GGTGTCTT,iTru5_08_C,ATCGCAAC,Controls,blank.39.C12
-blank_39_C4,blank_39_C4,Test Shotgun Library \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{6},E7,iTru7_103_01,CAGCGATT,iTru5_12_B,ATCTGACC,Controls,blank.39.C4
-blank_39_C5,blank_39_C5,Test Shotgun Library \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{6},E9,iTru7_103_02,TAGTGACC,iTru5_01_C,CACAGACT,Controls,blank.39.C5
-blank_39_C6,blank_39_C6,Test Shotgun Library \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{6},E11,iTru7_103_03,CGAGACTA,iTru5_02_C,CACTGTAG,Controls,blank.39.C6
-blank_39_C7,blank_39_C7,Test Shotgun Library \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{6},E13,iTru7_103_04,GACATGGT,iTru5_03_C,CACAGGAA,Controls,blank.39.C7
-blank_39_C8,blank_39_C8,Test Shotgun Library \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{6},E15,iTru7_103_05,GCATGTCT,iTru5_04_C,CCATGAAC,Controls,blank.39.C8
-blank_39_C9,blank_39_C9,Test Shotgun Library \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{6},E17,iTru7_103_06,ACTCCATC,iTru5_05_C,GCCAATAC,Controls,blank.39.C9
-blank_39_D1,blank_39_D1,Test Shotgun Library \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{6},G1,iTru7_103_10,AAGAAGGC,iTru5_09_C,GTTGCTGT,Controls,blank.39.D1
-blank_39_D10,blank_39_D10,Test Shotgun Library \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{6},G19,iTru7_104_07,TTAGGTCG,iTru5_06_D,TCGACAAG,Controls,blank.39.D10
-blank_39_D11,blank_39_D11,Test Shotgun Library \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{6},G21,iTru7_104_08,GCAAGATC,iTru5_07_D,GCTGAATC,Controls,blank.39.D11
-blank_39_D12,blank_39_D12,Test Shotgun Library \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{6},G23,iTru7_104_09,AGAGCCTT,iTru5_08_D,AGTTGTGC,Controls,blank.39.D12
-blank_39_D2,blank_39_D2,Test Shotgun Library \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{6},G3,iTru7_103_11,AGGTTCGA,iTru5_10_C,TCTAGTCC,Controls,blank.39.D2
-blank_39_D3,blank_39_D3,Test Shotgun Library \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{6},G5,iTru7_103_12,CATGTTCC,iTru5_11_C,GACGAACT,Controls,blank.39.D3
-blank_39_D4,blank_39_D4,Test Shotgun Library \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{6},G7,iTru7_104_01,GTGCCATA,iTru5_12_C,TTCGTACG,Controls,blank.39.D4
-blank_39_D5,blank_39_D5,Test Shotgun Library \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{6},G9,iTru7_104_02,CCTTGTAG,iTru5_01_D,CGACACTT,Controls,blank.39.D5
-blank_39_D6,blank_39_D6,Test Shotgun Library \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{6},G11,iTru7_104_03,GCTGGATT,iTru5_02_D,AGACGCTA,Controls,blank.39.D6
-blank_39_D7,blank_39_D7,Test Shotgun Library \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{6},G13,iTru7_104_04,TAACGAGG,iTru5_03_D,TGACAACC,Controls,blank.39.D7
-blank_39_D8,blank_39_D8,Test Shotgun Library \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{6},G15,iTru7_104_05,ATGGTTGC,iTru5_04_D,GGTACTTC,Controls,blank.39.D8
-blank_39_D9,blank_39_D9,Test Shotgun Library \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{6},G17,iTru7_104_06,CCTATACC,iTru5_05_D,CTGTATGC,Controls,blank.39.D9
-blank_39_E1,blank_39_E1,Test Shotgun Library \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{6},I1,iTru7_104_10,GCAATGGA,iTru5_09_D,TGTCGACT,Controls,blank.39.E1
-blank_39_E10,blank_39_E10,Test Shotgun Library \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{6},I19,iTru7_105_07,TGGCATGT,iTru5_06_E,TATGACCG,Controls,blank.39.E10
-blank_39_E11,blank_39_E11,Test Shotgun Library \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{6},I21,iTru7_105_08,AGAAGCGT,iTru5_07_E,AGCTAGTG,Controls,blank.39.E11
-blank_39_E12,blank_39_E12,Test Shotgun Library \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{6},I23,iTru7_105_09,AGCGGAAT,iTru5_08_E,GAACGAAG,Controls,blank.39.E12
-blank_39_E2,blank_39_E2,Test Shotgun Library \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{6},I3,iTru7_104_11,CTGGAGTA,iTru5_10_D,AAGGCTCT,Controls,blank.39.E2
-blank_39_E3,blank_39_E3,Test Shotgun Library \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{6},I5,iTru7_104_12,GAACATCG,iTru5_11_D,CCTAACAG,Controls,blank.39.E3
-blank_39_E4,blank_39_E4,Test Shotgun Library \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{6},I7,iTru7_105_01,GCACAACT,iTru5_12_D,AAGACGAG,Controls,blank.39.E4
-blank_39_E5,blank_39_E5,Test Shotgun Library \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{6},I9,iTru7_105_02,TTCTCTCG,iTru5_01_E,GACTTGTG,Controls,blank.39.E5
-blank_39_E6,blank_39_E6,Test Shotgun Library \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{6},I11,iTru7_105_03,AACGGTCA,iTru5_02_E,CAACTCCA,Controls,blank.39.E6
-blank_39_E7,blank_39_E7,Test Shotgun Library \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{6},I13,iTru7_105_04,ACAGACCT,iTru5_03_E,TGTTCCGT,Controls,blank.39.E7
-blank_39_E8,blank_39_E8,Test Shotgun Library \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{6},I15,iTru7_105_05,TCTCTTCC,iTru5_04_E,ACCGCTAT,Controls,blank.39.E8
-blank_39_E9,blank_39_E9,Test Shotgun Library \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{6},I17,iTru7_105_06,AGTGTTGG,iTru5_05_E,CTTAGGAC,Controls,blank.39.E9
-blank_39_F1,blank_39_F1,Test Shotgun Library \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{6},K1,iTru7_105_10,TAACCGGT,iTru5_09_E,CGTCTAAC,Controls,blank.39.F1
-blank_39_F10,blank_39_F10,Test Shotgun Library \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{6},K19,iTru7_106_07,CGTCTTGT,iTru5_06_F,AGCCAACT,Controls,blank.39.F10
-blank_39_F11,blank_39_F11,Test Shotgun Library \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{6},K21,iTru7_106_08,CGTGATCA,iTru5_07_F,CTAGCTCA,Controls,blank.39.F11
-blank_39_F12,blank_39_F12,Test Shotgun Library \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{6},K23,iTru7_106_09,CCAAGTTG,iTru5_08_F,GGAAGAGA,Controls,blank.39.F12
-blank_39_F2,blank_39_F2,Test Shotgun Library \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{6},K3,iTru7_105_11,CATGGAAC,iTru5_10_E,AACCAGAG,Controls,blank.39.F2
-blank_39_F3,blank_39_F3,Test Shotgun Library \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{6},K5,iTru7_105_12,ATGGTCCA,iTru5_11_E,CGCCTTAT,Controls,blank.39.F3
-blank_39_F4,blank_39_F4,Test Shotgun Library \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{6},K7,iTru7_106_01,CTTCTGAG,iTru5_12_E,CTCGTTCT,Controls,blank.39.F4
-blank_39_F5,blank_39_F5,Test Shotgun Library \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{6},K9,iTru7_106_02,AACCGAAG,iTru5_01_F,GTGAGACT,Controls,blank.39.F5
-blank_39_F6,blank_39_F6,Test Shotgun Library \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{6},K11,iTru7_106_03,TTCGTACC,iTru5_02_F,AACACGCT,Controls,blank.39.F6
-blank_39_F7,blank_39_F7,Test Shotgun Library \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{6},K13,iTru7_106_04,CTGTTAGG,iTru5_03_F,CCTAGAGA,Controls,blank.39.F7
-blank_39_F8,blank_39_F8,Test Shotgun Library \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{6},K15,iTru7_106_05,CACAAGTC,iTru5_04_F,TTCCAGGT,Controls,blank.39.F8
-blank_39_F9,blank_39_F9,Test Shotgun Library \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{6},K17,iTru7_106_06,TCTTGACG,iTru5_05_F,TCAGCCTT,Controls,blank.39.F9
-blank_39_G1,blank_39_G1,Test Shotgun Library \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{6},M1,iTru7_106_10,GTACCTTG,iTru5_09_F,AACACTGG,Controls,blank.39.G1
-blank_39_G10,blank_39_G10,Test Shotgun Library \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{6},M19,iTru7_107_07,CCGACTAT,iTru5_06_G,GATCTTGC,Controls,blank.39.G10
-blank_39_G11,blank_39_G11,Test Shotgun Library \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{6},M21,iTru7_107_08,AGCTAACC,iTru5_07_G,GTTAAGCG,Controls,blank.39.G11
-blank_39_G12,blank_39_G12,Test Shotgun Library \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{6},M23,iTru7_107_09,GCCTTGTT,iTru5_08_G,GTCATCGT,Controls,blank.39.G12
-blank_39_G2,blank_39_G2,Test Shotgun Library \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{6},M3,iTru7_106_11,GACTATGC,iTru5_10_F,ACTATCGC,Controls,blank.39.G2
-blank_39_G3,blank_39_G3,Test Shotgun Library \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{6},M5,iTru7_106_12,TGGATCAC,iTru5_11_F,ACAACAGC,Controls,blank.39.G3
-blank_39_G4,blank_39_G4,Test Shotgun Library \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{6},M7,iTru7_107_01,CTCTGGTT,iTru5_12_F,TGTGGCTT,Controls,blank.39.G4
-blank_39_G5,blank_39_G5,Test Shotgun Library \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{6},M9,iTru7_107_02,GTTCATGG,iTru5_01_G,GTTCCATG,Controls,blank.39.G5
-blank_39_G6,blank_39_G6,Test Shotgun Library \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{6},M11,iTru7_107_03,GCTGTAAG,iTru5_02_G,TGGATGGT,Controls,blank.39.G6
-blank_39_G7,blank_39_G7,Test Shotgun Library \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{6},M13,iTru7_107_04,GTCGAAGA,iTru5_03_G,GCATAACG,Controls,blank.39.G7
-blank_39_G8,blank_39_G8,Test Shotgun Library \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{6},M15,iTru7_107_05,GAGCTCAA,iTru5_04_G,TCGAACCT,Controls,blank.39.G8
-blank_39_G9,blank_39_G9,Test Shotgun Library \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{6},M17,iTru7_107_06,TGAACCTG,iTru5_05_G,ACATGCCA,Controls,blank.39.G9
-blank_39_H1,blank_39_H1,Test Shotgun Library \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{6},O1,iTru7_107_10,AACTTGCC,iTru5_09_G,TCAGACAC,Controls,blank.39.H1
-blank_39_H10,blank_39_H10,Test Shotgun Library \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{6},O19,iTru7_108_07,GAAGTACC,iTru5_06_H,CCTCGTTA,Controls,blank.39.H10
-blank_39_H11,blank_39_H11,Test Shotgun Library \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{6},O21,iTru7_108_08,CAGGTATC,iTru5_07_H,CGATTGGA,Controls,blank.39.H11
-blank_39_H12,blank_39_H12,Test Shotgun Library \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{6},O23,iTru7_108_09,TCTCTAGG,iTru5_08_H,CCAACGAA,Controls,blank.39.H12
-blank_39_H2,blank_39_H2,Test Shotgun Library \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{6},O3,iTru7_107_11,CAATGTGG,iTru5_10_G,GTCCTAAG,Controls,blank.39.H2
-blank_39_H3,blank_39_H3,Test Shotgun Library \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{6},O5,iTru7_107_12,AAGGCTGA,iTru5_11_G,AGACCTTG,Controls,blank.39.H3
-blank_39_H4,blank_39_H4,Test Shotgun Library \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{6},O7,iTru7_108_01,TTACCGAG,iTru5_12_G,AGACATGC,Controls,blank.39.H4
-blank_39_H5,blank_39_H5,Test Shotgun Library \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{6},O9,iTru7_108_02,GTCCTAAG,iTru5_01_H,TAGCTGAG,Controls,blank.39.H5
-blank_39_H6,blank_39_H6,Test Shotgun Library \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{6},O11,iTru7_108_03,GAAGGTTC,iTru5_02_H,TTCGAAGC,Controls,blank.39.H6
-blank_39_H7,blank_39_H7,Test Shotgun Library \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{6},O13,iTru7_108_04,GAAGAGGT,iTru5_03_H,CAGTGCTT,Controls,blank.39.H7
-blank_39_H8,blank_39_H8,Test Shotgun Library \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{6},O15,iTru7_108_05,TCTGAGAG,iTru5_04_H,TAGTGCCA,Controls,blank.39.H8
-blank_39_H9,blank_39_H9,Test Shotgun Library \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{6},O17,iTru7_108_06,ACCGCATA,iTru5_05_H,GATGGAGT,Controls,blank.39.H9"""  # noqa
 
 
 if __name__ == '__main__':

--- a/labman/gui/handlers/process_handlers/gdna_extraction_process.py
+++ b/labman/gui/handlers/process_handlers/gdna_extraction_process.py
@@ -47,7 +47,7 @@ class GDNAExtractionProcessHandler(BaseHandler):
             sample_plate = process.sample_plate.id
             externally_extracted = process.externally_extracted
             volume = process.volume
-            ext_date = process.date.strftime('%Y/%m/%d')
+            ext_date = process.date.strftime(process.get_date_format())
             notes = process.notes
 
         ep_robots = Equipment.list_equipment('EpMotion')

--- a/labman/gui/handlers/process_handlers/library_prep_16s_process.py
+++ b/labman/gui/handlers/process_handlers/library_prep_16s_process.py
@@ -47,7 +47,7 @@ class LibraryPrep16SProcessHandler(BaseHandler):
             water_lot = process.water_lot.external_lot_id
             primer_plate = process.primer_plate.id
             volume = process.volume
-            prep_date = process.date.strftime('%Y/%m/%d')
+            prep_date = process.date.strftime(process.get_date_format())
 
         robots = Equipment.list_equipment('EpMotion')
         tools_tm300_8 = Equipment.list_equipment(

--- a/labman/gui/handlers/process_handlers/pooling_process.py
+++ b/labman/gui/handlers/process_handlers/pooling_process.py
@@ -369,14 +369,15 @@ class LibraryPoolProcessHandler(BasePoolHandler):
 
             plate_result = self._compute_pools(pinfo)
             plate = Plate(plate_result['plate_id'])
-            pool_name = 'Pool from plate %s (%s)' % (
-                plate.external_id,
-                datetime.now().strftime('%Y-%m-%d %H:%M:%S'))
+
             # create input molar percentages
             pcts = calc_pool_pcts(plate_result['comp_vals'],
                                   plate_result['pool_vals'])
             quant_process = QuantificationProcess(
                 plate_result['quant-process-id'])
+            pool_name = 'Pool from plate %s (%s)' % (
+                plate.external_id,
+                datetime.now().strftime(quant_process.get_date_format()))
             input_compositions = []
             for comp, _, _ in quant_process.concentrations:
                 well = comp.container

--- a/labman/gui/templates/sequence_run_list.html
+++ b/labman/gui/templates/sequence_run_list.html
@@ -15,11 +15,15 @@
           "/sample_sheet' class='btn btn-success'>" +
           "<span class='glyphicon glyphicon-download'></span> " +
           "Download Sample Sheet</a>";
-        var preparationSheets = "<a href='/process/sequencing/" + row[5] +
-          "/preparation_sheets' class='btn btn-success'>" +
-          "<span class='glyphicon glyphicon-download'></span> " +
-          "Download Preparation Sheets</a>";
 
+        // ToDo: #327
+        var preparationSheets = '';
+        if (row[3] == 'Amplicon') {
+          preparationSheets = "<a href='/process/sequencing/" + row[5] +
+            "/preparation_sheets' class='btn btn-success'>" +
+            "<span class='glyphicon glyphicon-download'></span> " +
+            "Download Preparation Sheets</a>";
+        }
         newData.push([row[0], row[1], row[2], row[3], row[4], sampleSheet,
                       preparationSheets]);
       }

--- a/labman/gui/templates/sequence_run_list.html
+++ b/labman/gui/templates/sequence_run_list.html
@@ -10,22 +10,29 @@
     $.get('/sequence_run_list', function(data) {
       var datatable = $('#sequenceRunListTable').DataTable();
       var newData = [];
+
+      var process_id = 0;
+      var run_name = 1;
+      var experiment_name = 2;
+      var assay_type = 3;
+      var pi_name = 4;
+      var sequencing_process_id = 5;
       for (var row of data.data) {
         var sampleSheet = "<a href='/process/sequencing/" + row[5] +
           "/sample_sheet' class='btn btn-success'>" +
           "<span class='glyphicon glyphicon-download'></span> " +
           "Download Sample Sheet</a>";
 
-        // ToDo: #327
         var preparationSheets = '';
-        if (row[3] == 'Amplicon') {
-          preparationSheets = "<a href='/process/sequencing/" + row[5] +
+        if (row[assay_type] == 'Amplicon') {
+          preparationSheets = "<a href='/process/sequencing/" +
+            row[sequencing_process_id] +
             "/preparation_sheets' class='btn btn-success'>" +
             "<span class='glyphicon glyphicon-download'></span> " +
             "Download Preparation Sheets</a>";
         }
-        newData.push([row[0], row[1], row[2], row[3], row[4], sampleSheet,
-                      preparationSheets]);
+        newData.push([row[process_id], row[run_name], row[experiment_name],
+            row[assay_type], row[pi_name], sampleSheet, preparationSheets]);
       }
       datatable.clear();
       datatable.rows.add(newData);


### PR DESCRIPTION
Migrated from PR 330, work by @antgonza  :
closes #329 change from timestamptz to timestamp for process dates
fixes #336 ensure Process.get_date_format() is used for date display
fixes #326 disable preparation sheet download for shotgun runs