### PR TITLE
Fix breaking issues identified during initial real-data test

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,5 +113,3 @@ use the optional `--port` switch, as shown in the below example to start it on p
 ```bash
 labman start_webserver --port 5555
 ```
-
-

--- a/README.md
+++ b/README.md
@@ -84,10 +84,34 @@ creating a production or production-like environment, run:
 psql -d qiita_test -f labman/db/support_files/populate_prod_db.sql
 ```
 
+Note that the postgres user specified for the labman software (`labman` in the config example above) 
+must be granted "select" permissions on all tables in the "qiita" schema and "all" permissions on
+all tables in the "labman" schema, as well as being the owner of all tables in the "labman" schema.  
+These ownerships and permissions can be granted with SQL like that shown below, after setting the
+USER variable to be the postgres user specified for the labman software and DB to be the 
+database name for your Qiita installation:
+
+```bash
+USER=labman
+DB=qiita_test
+SCHEMA=labman
+for table in `psql -tc "select tablename from pg_tables where schemaname = '${SCHEMA}';" ${DB}` ; do psql -c "alter table ${SCHEMA}.${table} owner to ${USER}" ${DB}; done
+psql -d qiita-test -c "Grant select on all tables in schema qiita to ${USER};"
+psql -d qiita-test -c "Grant all on all tables in schema labman to ${USER};"
+```
+
 Labman is now ready to run.  Start the labman server with:
 
 ```bash
 labman start_webserver
 ```
 
-If it is running successfully, you will see the message `Labman started on port 8080`.
+If it is running successfully, you will see the message `Labman started on port 8080`.  Note that 
+by default, labman starts on port 8080; if you would like to start it on a different port, 
+use the optional `--port` switch, as shown in the below example to start it on port 5555:
+
+```bash
+labman start_webserver --port 5555
+```
+
+

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -58,7 +58,7 @@ Once your plate name is created, you will be asked to fill in information regard
 
 Below “Plate configuration” you will be asked to choose the “Studies being plated.” After choosing “Add Study”, a list of studies available in the database will appear. On this page, select the green plus sign to add a study to your plate. If you want to add an additional study, simply select “Add Study” again and repeat the steps—this will allow you to combine samples from multiple studies onto a single plate.
 
-After choosing a “Plate configuration,” a table will be created that matches your plate type. Here you can insert your sample names. Each well will autofill from your study, or studies, selected and will show 20 options at a time. These wells are case sensitive. Be sure to type the study ID in front of your sample name. 
+After choosing a “Plate configuration,” a table will be created that matches your plate type. Here you can insert your sample names. Each sample name must be prefixed with its study id and a period; if you are typing in well contents, autocomplete will display matching study+sample ids from your selected study or studies (20 options at a time). However, if you are pasting in sample ids, you must append the study id prefix yourself.  These wells are case sensitive.
 
 If your samples are not found within your metadata from your Qiita study, you will receive an error. If your sample names are long and you are unable to read them, you can resize the columns by dragging the edges. 
 
@@ -66,7 +66,7 @@ If you input 2 identical sample names on the same plate, both wells will become 
 
 If you input a sample that is already on another plate within your study, you will be alerted with a message in your “Well comments” text box at the bottom of your screen.
 
-If you want to add a comment to a well, right click the well after you have added a sample name. Once you select “Add comment,” an “Add comment to well” window will pop-up where you can input a note. The edges of your sample name will now be highlighted green and your comment will appear in the “Well comments” text box. To remove or edit your comment, right click the well. Select the “Add comment” again to make your edits in the pop-up window. 
+If you want to add a comment to a well, right click the well after you have added a sample name *and exited edit mode*. Once you select “Add comment,” an “Add comment to well” window will pop-up where you can input a note. The edges of your sample name will now be highlighted green and your comment will appear in the “Well comments” text box. To remove or edit your comment, right click the well. Select the “Add comment” again to make your edits in the pop-up window.
 
 When you are finished plating your samples, select “Save” and you will be returned to the home screen.
 

--- a/labman/db/tests/tester.py
+++ b/labman/db/tests/tester.py
@@ -209,7 +209,7 @@ def integration_tests_shotgun_workflow(user, samples):
     return seq_process
 
 
-@tester.command()
+@tester.command("integration_tests")
 def integration_tests():
     """Creates one amplicon and one shotgun workflow from plating to sequencing
     """
@@ -382,7 +382,7 @@ def stress_tests_shotgun_workflow(user, samples, num_plates=1):
             create_sequencing_process(user, [pool_process.pool])
 
 
-@tester.command()
+@tester.command("stress_tests")
 @click.option('--num_plates', required=False, type=click.IntRange(1, None),
               default=10, show_default=True,
               help='Number of plates to create per workflow')

--- a/labman/gui/handlers/process_handlers/sample_plating_process.py
+++ b/labman/gui/handlers/process_handlers/sample_plating_process.py
@@ -77,6 +77,14 @@ def sample_plating_process_handler_patch_request(
             study_id = int(req_path[3])
             well_attribute = req_path[4]
 
+            # The default values of the variables sample_id and
+            # blank_or_unknown are set before the try, and these are the values
+            # that are used if either (a) study_id is not 0 OR (b) the try
+            # fails with a ValueError (see comment in try below). If the try
+            # fails with anything other than a ValueError then the entire
+            # function bails, so it doesn't matter what these variables are set
+            # to. If and only if the try succeeds are these variables set to
+            # the values within the try.
             sample_id = req_value
             blank_or_unknown = True
 
@@ -85,6 +93,16 @@ def sample_plating_process_handler_patch_request(
             # the fully qualified sample id(s)--i.e., <studyid>.<sampleid>.
             if study_id != 0:
                 try:
+                    # Note that the try fails iff the
+                    # Study(study_id).specimen_id_to_sample_id() call fails,
+                    # as the blank_or_unknown = False can't really fail ...
+                    # this assures that we can't realistically end up in an
+                    # inconsistent situation where sample_id has been set
+                    # during the try but blank_or_unknown has not.
+                    #
+                    # Thus, the ordering of these two statements within the try
+                    # is really important: do not change it unless you
+                    # understand all of the above!
                     sample_id = Study(study_id).specimen_id_to_sample_id(
                         req_value)
                     blank_or_unknown = False

--- a/labman/gui/handlers/process_handlers/sample_plating_process.py
+++ b/labman/gui/handlers/process_handlers/sample_plating_process.py
@@ -77,12 +77,21 @@ def sample_plating_process_handler_patch_request(
             study_id = int(req_path[3])
             well_attribute = req_path[4]
 
-            blank_or_unknown = False
-            try:
-                sample_id = Study(study_id).specimen_id_to_sample_id(req_value)
-            except ValueError:
-                sample_id = req_value
-                blank_or_unknown = True
+            sample_id = req_value
+            blank_or_unknown = True
+
+            # It actually IS possible to plate a plate without specifying
+            # separate study id(s); can plate just all blanks, or can provide
+            # the fully qualified sample id(s)--i.e., <studyid>.<sampleid>.
+            if study_id != 0:
+                try:
+                    sample_id = Study(study_id).specimen_id_to_sample_id(
+                        req_value)
+                    blank_or_unknown = False
+                except ValueError:
+                    pass
+                # end try/except
+            # end if
 
             if well_attribute == 'sample':
                 if req_value is None or not req_value.strip():

--- a/labman/gui/static/js/plateViewer.js
+++ b/labman/gui/static/js/plateViewer.js
@@ -353,7 +353,12 @@ PlateViewer.prototype.loadPlateLayout = function () {
 };
 
 /**
- * Fetch the study that is currently selected in the UI
+ * Fetch the study that is currently selected in the UI.
+ * If there is NO selected study in the UI, then the
+ * method returns 0 (which is not a valid study id).
+ * This special non-valid value is checked for in the
+ * back end (in sample_plating_process_handler_patch_request)
+ * so do not change here without changing there.
  */
 PlateViewer.prototype.getActiveStudy = function () {
   studyID = get_active_studies().pop();
@@ -435,8 +440,8 @@ PlateViewer.prototype.commentWell = function (row, col, comment) {
 /**
  * Update the contents of the grid
  *
- * This method is mainly motivated by updateDuplicates and updateUnknown, both
- * of which may need to update cells that were not recently updated.
+ * This method is mainly motivated by updateUnknownsAndDuplicates,
+ * which may need to update cells that were not recently updated.
  *
  * Here and in the rest of the source we use updateRow instead of
  * invalidateRows and render so that we don't lose any active editors in the

--- a/labman/gui/templates/plate_list.html
+++ b/labman/gui/templates/plate_list.html
@@ -23,7 +23,7 @@
                              'description': 'Shotgun library plates'}}
 
   function buttonClicked(address) {
-    var plateIds = []
+    var plateIds = [];
     for (var inTag of $('.dt-selected').find('input')) {
       plateIds.push($(inTag).attr('data-lb-plate-id'));
     }
@@ -32,13 +32,13 @@
       urlArgs = urlArgs + "&plate_id=" + pId;
     }
     window.location.href = address + urlArgs;
-  };
+  }
 
   function generateBtnDOM (label, urlTarget) {
     $('<button>').addClass('btn btn-info').append(label).appendTo('#btn-div').on('click', function () {
       buttonClicked(urlTarget);
     });
-  };
+  }
 
   /**
    *
@@ -50,6 +50,10 @@
    */
   function discardPlate(id, node) {
     var $node = $(node), $table;
+
+    var do_discard = confirm("Discarded plates are marked as discarded in the database but are not deleted.  They are no longer accessible anywhere in the interface.  Discarding can only be undone by a database administrator.  Do you want to discard this plate?");
+    if (!do_discard){return;}
+
     $node.addClass('disabled');
 
     $.ajax({
@@ -58,7 +62,7 @@
       data: {op: 'replace', path: '/discarded/', value: true},
       success: function(data, textStatus, request) {
         // taken from: https://datatables.net/reference/api/row().remove()
-        $table = $('#plateListTable').DataTable()
+        $table = $('#plateListTable').DataTable();
         $table.row($node.parents('tr')).remove().draw();
       },
       error: function(request, stat, error) {
@@ -98,9 +102,9 @@
                        '</a> ' +
                        '<input type="checkbox" class="table-checkbox" data-lb-plate-id="' + row[0] + '"></input>');
 
-          var deleteButton = '<a onclick="discardPlate(' + row[0] + ', this)" class="btn btn-danger btn-circle-small">' +
-                               '<span class="glyphicon glyphicon-remove" data-toggle="tooltip" title="Remove plate"></span>' +
-                             '</a> ';
+          var deleteButton = '<button onclick="discardPlate(' + row[0] + ', this)" class="btn btn-danger">Discard Plate ' +
+                               '<span class="glyphicon glyphicon-remove" data-toggle="tooltip" title="Discard plate"></span>' +
+                             '</button> ';
           // row[0] = plate id, row[1] = external id, row[2] = list of names of
           // studies associated with any sample on plate (may be empty list)
           newData.push([chBox, row[0], row[1], row[2].join('<br />'), deleteButton]);

--- a/scripts/labman
+++ b/scripts/labman
@@ -16,7 +16,7 @@ def labman():
     pass
 
 
-@labman.command()
+@labman.command("start_webserver")
 @click.option('--port', required=False, type=int,
               help="Port where the webserver will start", default=8080)
 def start_webserver(port):


### PR DESCRIPTION
Closes #356 Reduce number of GET calls during sample plating
Closes #353 Prevent unhandled exception when trying to plate a sample without a study selected
Closes #359 Upgrade command-line command names to work with click library version 7
Closes #357 Prevent uninformed discarding of plates
Closes #358 Include database permission requirements in install directions