### PR TITLE
Support externally extracted gDNA plates in production

### DIFF
--- a/labman/db/support_files/populate_test_db.sql
+++ b/labman/db/support_files/populate_test_db.sql
@@ -23,13 +23,6 @@ DECLARE
     rc_process_id_w                     BIGINT;
     reagent_comp_type                   BIGINT;
 
-    -- Variables for externally extracted samples
-    rc_process_id_none                  BIGINT;
-    none_container_id                   BIGINT;
-    none_composition_id                 BIGINT;
-    none_reagent_composition_id         BIGINT;
-    none_reagent_comp_type              BIGINT;
-
     -- Variables for primer working plates
     wpp_process_type_id                 BIGINT;
     wpp_process_id                      BIGINT;
@@ -1238,29 +1231,5 @@ BEGIN
 
     -- Update the combo index value
     UPDATE labman.shotgun_primer_set SET current_combo_index = combo_idx;
-
-    -- Add 'Not applicable' reagents for externally extracted samples
-    INSERT INTO labman.process (process_type_id, run_date, run_personnel_id)
-        VALUES (rc_process_type_id, '05/01/1984', 'test@foo.bar')
-        RETURNING process_id INTO rc_process_id_none;
-
-    INSERT INTO labman.container (container_type_id, latest_upstream_process_id, remaining_volume)
-        VALUES (tube_container_type_id, rc_process_id_none, 42)
-        RETURNING container_id INTO none_container_id;
-
-    INSERT INTO labman.tube (container_id, external_id)
-        VALUES (none_container_id, 'Not applicable');
-
-    SELECT reagent_composition_type_id INTO none_reagent_comp_type
-        FROM labman.reagent_composition_type
-        WHERE description = 'extraction kit';
-
-    INSERT INTO labman.composition (composition_type_id, upstream_process_id, container_id, total_volume)
-        VALUES (reagent_comp_type, rc_process_id_none, none_container_id, 42)
-        RETURNING composition_id INTO none_composition_id;
-
-    INSERT INTO labman.reagent_composition (composition_id, reagent_composition_type_id, external_lot_id)
-        VALUES (none_composition_id, none_reagent_comp_type, 'Not applicable')
-        RETURNING reagent_composition_id INTO none_reagent_composition_id;
 
 END $do$

--- a/labman/db/tests/test_composition.py
+++ b/labman/db/tests/test_composition.py
@@ -29,20 +29,20 @@ from labman.db.composition import (
 # the tests from ~12 minutes to ~2 minutes
 class TestsComposition(LabmanTestCase):
     def test_composition_factory(self):
-        self.assertEqual(Composition.factory(3073), ReagentComposition(1))
-        self.assertEqual(Composition.factory(1537), PrimerComposition(1))
+        self.assertEqual(Composition.factory(3074), ReagentComposition(2))
+        self.assertEqual(Composition.factory(1538), PrimerComposition(1))
         self.assertEqual(Composition.factory(1), PrimerSetComposition(1))
-        self.assertEqual(Composition.factory(3081), SampleComposition(1))
-        self.assertEqual(Composition.factory(3082), GDNAComposition(1))
-        self.assertEqual(Composition.factory(3083),
-                         LibraryPrep16SComposition(1))
+        self.assertEqual(Composition.factory(3082), SampleComposition(1))
+        self.assertEqual(Composition.factory(3083), GDNAComposition(1))
         self.assertEqual(Composition.factory(3084),
-                         CompressedGDNAComposition(1))
+                         LibraryPrep16SComposition(1))
         self.assertEqual(Composition.factory(3085),
-                         NormalizedGDNAComposition(1))
+                         CompressedGDNAComposition(1))
         self.assertEqual(Composition.factory(3086),
+                         NormalizedGDNAComposition(1))
+        self.assertEqual(Composition.factory(3087),
                          LibraryPrepShotgunComposition(1))
-        self.assertEqual(Composition.factory(3078), PoolComposition(1))
+        self.assertEqual(Composition.factory(3079), PoolComposition(1))
 
     def test_reagent_composition_list_reagents(self):
         obs = ReagentComposition.list_reagents()
@@ -68,17 +68,17 @@ class TestsComposition(LabmanTestCase):
 
     def test_reagent_composition_from_external_id(self):
         self.assertEqual(ReagentComposition.from_external_id('157022406'),
-                         ReagentComposition(1))
+                         ReagentComposition(2))
         with self.assertRaises(LabmanUnknownIdError):
             ReagentComposition.from_external_id('Does not exist')
 
     def test_reagent_composition_attributes(self):
-        obs = ReagentComposition(1)
-        self.assertEqual(obs.upstream_process, ReagentCreationProcess(5))
-        self.assertEqual(obs.container, Tube(1))
+        obs = ReagentComposition(2)
+        self.assertEqual(obs.upstream_process, ReagentCreationProcess(6))
+        self.assertEqual(obs.container, Tube(2))
         self.assertEqual(obs.total_volume, 10)
         self.assertIsNone(obs.notes)
-        self.assertEqual(obs.composition_id, 3073)
+        self.assertEqual(obs.composition_id, 3074)
         self.assertEqual(obs.external_lot_id, '157022406')
         self.assertEqual(obs.reagent_type, 'extraction kit')
         self.assertIsNone(obs.study)
@@ -88,7 +88,14 @@ class TestsComposition(LabmanTestCase):
         self.assertEqual(obs.container, Well(1537))
         self.assertEqual(obs.total_volume, 10)
         self.assertIsNone(obs.notes)
-        self.assertEqual(obs.composition_id, 1537)
+        # NB: the fact that the composition id is 1538 and the well id is 1537
+        # is not a mistake.  There is a placeholder composition (for "Not
+        # Applicable", supporting externally extracted DNA) added in
+        # db_patch_manual.sql, before populate_test_db.sql is run to create the
+        # records being tested here--but that composition is "stored" in a
+        # placeholder TUBE rather than a placeholder WELL, so there is no
+        # analogous extra well record.
+        self.assertEqual(obs.composition_id, 1538)
         self.assertEqual(obs.primer_set_composition, PrimerSetComposition(1))
         self.assertIsNone(obs.study)
 
@@ -166,7 +173,7 @@ class TestsComposition(LabmanTestCase):
         self.assertEqual(obs.sample_composition_type, 'experimental sample')
         self.assertEqual(obs.sample_id, '1.SKB1.640202')
         self.assertEqual(obs.content, '1.SKB1.640202.21.A1')
-        self.assertEqual(obs.upstream_process, SamplePlatingProcess(10))
+        self.assertEqual(obs.upstream_process, SamplePlatingProcess(11))
         self.assertEqual(obs.container, Well(3073))
         self.assertEqual(obs.total_volume, 10)
         self.assertIsNone(obs.notes)
@@ -174,7 +181,7 @@ class TestsComposition(LabmanTestCase):
         self.assertEqual(obs.notes, 'New Notes')
         obs.notes = None
         self.assertIsNone(obs.notes)
-        self.assertEqual(obs.composition_id, 3081)
+        self.assertEqual(obs.composition_id, 3082)
         self.assertEqual(obs.study, Study(1))
 
         # Test a control sample
@@ -182,11 +189,11 @@ class TestsComposition(LabmanTestCase):
         self.assertEqual(obs.sample_composition_type, 'blank')
         self.assertIsNone(obs.sample_id)
         self.assertEqual(obs.content, 'blank.21.H1')
-        self.assertEqual(obs.upstream_process, SamplePlatingProcess(10))
+        self.assertEqual(obs.upstream_process, SamplePlatingProcess(11))
         self.assertEqual(obs.container, Well(3115))
         self.assertEqual(obs.total_volume, 10)
         self.assertIsNone(obs.notes)
-        self.assertEqual(obs.composition_id, 3123)
+        self.assertEqual(obs.composition_id, 3124)
         self.assertIsNone(obs.study)
 
     def test_sample_composition_get_sample_composition_type_id(self):
@@ -274,7 +281,7 @@ class TestsComposition(LabmanTestCase):
         self.assertEqual(obs.container, Well(3074))
         self.assertEqual(obs.total_volume, 10)
         self.assertIsNone(obs.notes)
-        self.assertEqual(obs.composition_id, 3082)
+        self.assertEqual(obs.composition_id, 3083)
         self.assertEqual(obs.study, Study(1))
 
     def test_library_prep_16S_composition_attributes(self):
@@ -284,7 +291,7 @@ class TestsComposition(LabmanTestCase):
         self.assertIsNone(obs.notes)
         self.assertEqual(obs.gdna_composition, GDNAComposition(1))
         self.assertEqual(obs.primer_composition, PrimerComposition(1))
-        self.assertEqual(obs.composition_id, 3083)
+        self.assertEqual(obs.composition_id, 3084)
         self.assertEqual(obs.study, Study(1))
 
     def test_compressed_gDNA_composition_attributes(self):
@@ -303,7 +310,7 @@ class TestsComposition(LabmanTestCase):
                          CompressedGDNAComposition(1))
         self.assertEqual(obs.dna_volume, 415)
         self.assertEqual(obs.water_volume, 3085)
-        self.assertEqual(obs.composition_id, 3085)
+        self.assertEqual(obs.composition_id, 3086)
         self.assertEqual(obs.study, Study(1))
 
     def test_library_prep_shotgun_composition_attributes(self):
@@ -315,7 +322,7 @@ class TestsComposition(LabmanTestCase):
                          NormalizedGDNAComposition(1))
         self.assertEqual(obs.i5_composition, PrimerComposition(769))
         self.assertEqual(obs.i7_composition, PrimerComposition(770))
-        self.assertEqual(obs.composition_id, 3086)
+        self.assertEqual(obs.composition_id, 3087)
         self.assertEqual(obs.study, Study(1))
 
     def test_pool_composition_get_components_type(self):
@@ -333,10 +340,10 @@ class TestsComposition(LabmanTestCase):
 
     def test_pool_composition_attributes(self):
         obs = PoolComposition(1)
-        self.assertEqual(obs.container, Tube(6))
+        self.assertEqual(obs.container, Tube(7))
         self.assertEqual(obs.total_volume, 96)
         self.assertIsNone(obs.notes)
-        self.assertEqual(obs.composition_id, 3078)
+        self.assertEqual(obs.composition_id, 3079)
         obs_comp = obs.components
         self.assertEqual(len(obs_comp), 95)
         exp = {'composition': LibraryPrep16SComposition(1),

--- a/labman/db/tests/test_container.py
+++ b/labman/db/tests/test_container.py
@@ -17,21 +17,21 @@ from labman.db.composition import PoolComposition, SampleComposition
 
 class TestContainer(LabmanTestCase):
     def test_factory(self):
-        self.assertEqual(Container.factory(3076), Tube(4))
-        self.assertEqual(Container.factory(1824), Well(1824))
+        self.assertEqual(Container.factory(3077), Tube(5))
+        self.assertEqual(Container.factory(1825), Well(1824))
 
 
 class TestTube(LabmanTestCase):
     # The creation of a tube is always linked to a Process, we are going to
     # test the creation of a tube on those processes rather than here
     def test_properties(self):
-        tester = Tube(6)
+        tester = Tube(7)
         self.assertEqual(tester.external_id, 'Test Pool from Plate 1')
         self.assertFalse(tester.discarded)
         self.assertEqual(tester.remaining_volume, 96)
         self.assertIsNone(tester.notes)
         self.assertEqual(tester.latest_process, PoolingProcess(1))
-        self.assertEqual(tester.container_id, 3078)
+        self.assertEqual(tester.container_id, 3079)
         self.assertEqual(tester.composition, PoolComposition(1))
 
     def test_discarded(self):
@@ -53,8 +53,8 @@ class TestWell(LabmanTestCase):
         self.assertEqual(tester.column, 1)
         self.assertEqual(tester.remaining_volume, 10)
         self.assertIsNone(tester.notes)
-        self.assertEqual(tester.latest_process, SamplePlatingProcess(10))
-        self.assertEqual(tester.container_id, 3081)
+        self.assertEqual(tester.latest_process, SamplePlatingProcess(11))
+        self.assertEqual(tester.container_id, 3082)
         self.assertEqual(tester.composition, SampleComposition(1))
 
     def test_well_id(self):

--- a/labman/db/tests/test_container.py
+++ b/labman/db/tests/test_container.py
@@ -35,11 +35,11 @@ class TestTube(LabmanTestCase):
         self.assertEqual(tester.composition, PoolComposition(1))
 
     def test_discarded(self):
-        tester = Tube(7)
+        tester = Tube(8)
         self.assertFalse(tester.discarded)
         tester.discard()
         self.assertTrue(tester.discarded)
-        regex = "Can't discard tube 7: it's already discarded."
+        regex = "Can't discard tube 8: it's already discarded."
         self.assertRaisesRegex(ValueError, regex, tester.discard)
 
 

--- a/labman/db/tests/test_plate.py
+++ b/labman/db/tests/test_plate.py
@@ -280,7 +280,7 @@ class TestPlate(LabmanTestCase):
             self.assertEqual(len(row), 12)
         self.assertEqual(tester.studies, {Study(1)})
         self.assertListEqual(tester.quantification_processes, [])
-        self.assertEqual(tester.process, SamplePlatingProcess(10))
+        self.assertEqual(tester.process, SamplePlatingProcess(11))
 
         # Test changing the name of the plate
         tester.external_id = 'Some new name'

--- a/labman/db/tests/test_process.py
+++ b/labman/db/tests/test_process.py
@@ -52,37 +52,37 @@ def _help_make_datetime(input_datetime_str):
 
 class TestProcess(LabmanTestCase):
     def test_factory(self):
-        self.assertEqual(Process.factory(10),
-                         SamplePlatingProcess(10))
-        self.assertEqual(Process.factory(5),
-                         ReagentCreationProcess(5))
-        self.assertEqual(Process.factory(3),
-                         PrimerWorkingPlateCreationProcess(1))
         self.assertEqual(Process.factory(11),
-                         GDNAExtractionProcess(1))
-        self.assertEqual(Process.factory(18),
-                         GDNAPlateCompressionProcess(1))
+                         SamplePlatingProcess(11))
+        self.assertEqual(Process.factory(6),
+                         ReagentCreationProcess(6))
+        self.assertEqual(Process.factory(4),
+                         PrimerWorkingPlateCreationProcess(1))
         self.assertEqual(Process.factory(12),
-                         LibraryPrep16SProcess(1))
-        self.assertEqual(Process.factory(20),
-                         NormalizationProcess(1))
-        self.assertEqual(Process.factory(21),
-                         LibraryPrepShotgunProcess(1))
+                         GDNAExtractionProcess(1))
+        self.assertEqual(Process.factory(19),
+                         GDNAPlateCompressionProcess(1))
         self.assertEqual(Process.factory(13),
-                         QuantificationProcess(1))
+                         LibraryPrep16SProcess(1))
+        self.assertEqual(Process.factory(21),
+                         NormalizationProcess(1))
+        self.assertEqual(Process.factory(22),
+                         LibraryPrepShotgunProcess(1))
         self.assertEqual(Process.factory(14),
+                         QuantificationProcess(1))
+        self.assertEqual(Process.factory(15),
                          QuantificationProcess(2))
-        self.assertEqual(Process.factory(15), PoolingProcess(1))
-        self.assertEqual(Process.factory(17), SequencingProcess(1))
+        self.assertEqual(Process.factory(16), PoolingProcess(1))
+        self.assertEqual(Process.factory(18), SequencingProcess(1))
 
 
 class TestSamplePlatingProcess(LabmanTestCase):
     def test_attributes(self):
-        tester = SamplePlatingProcess(10)
+        tester = SamplePlatingProcess(11)
         self.assertEqual(tester.date,
                          _help_make_datetime('2017-10-25 19:10:25'))
         self.assertEqual(tester.personnel, User('test@foo.bar'))
-        self.assertEqual(tester.process_id, 10)
+        self.assertEqual(tester.process_id, 11)
         self.assertEqual(tester.plate, Plate(21))
 
     def test_create(self):
@@ -124,7 +124,7 @@ class TestSamplePlatingProcess(LabmanTestCase):
                 self.assertEqual(obs_composition.total_volume, 10)
 
     def test_update_well(self):
-        tester = SamplePlatingProcess(10)
+        tester = SamplePlatingProcess(11)
         obs = SampleComposition(8)
 
         self.assertEqual(obs.sample_composition_type, 'blank')
@@ -154,7 +154,7 @@ class TestSamplePlatingProcess(LabmanTestCase):
         self.assertIsNone(obs.sample_id)
         self.assertEqual(obs.content, 'vibrio.positive.control.21.H1')
 
-        # Update a well from CONROL -> CONTROL
+        # Update a well from CONTROL -> CONTROL
         self.assertEqual(tester.update_well(8, 1, 'blank'),
                          ('blank.21.H1', True))
         self.assertEqual(obs.sample_composition_type, 'blank')
@@ -162,7 +162,7 @@ class TestSamplePlatingProcess(LabmanTestCase):
         self.assertEqual(obs.content, 'blank.21.H1')
 
     def test_comment_well(self):
-        tester = SamplePlatingProcess(10)
+        tester = SamplePlatingProcess(11)
         obs = SampleComposition(8)
 
         self.assertIsNone(obs.notes)
@@ -172,7 +172,7 @@ class TestSamplePlatingProcess(LabmanTestCase):
         self.assertIsNone(obs.notes)
 
     def test_notes(self):
-        tester = SamplePlatingProcess(10)
+        tester = SamplePlatingProcess(11)
 
         self.assertIsNone(tester.notes)
         tester.notes = 'This note was set in a test'
@@ -181,12 +181,12 @@ class TestSamplePlatingProcess(LabmanTestCase):
 
 class TestReagentCreationProcess(LabmanTestCase):
     def test_attributes(self):
-        tester = ReagentCreationProcess(5)
+        tester = ReagentCreationProcess(6)
         self.assertEqual(tester.date,
                          _help_make_datetime('2017-10-23 09:10:25'))
         self.assertEqual(tester.personnel, User('test@foo.bar'))
-        self.assertEqual(tester.process_id, 5)
-        self.assertEqual(tester.tube, Tube(1))
+        self.assertEqual(tester.process_id, 6)
+        self.assertEqual(tester.tube, Tube(2))
 
     def test_create(self):
         user = User('test@foo.bar')
@@ -220,7 +220,7 @@ class TestPrimerWorkingPlateCreationProcess(LabmanTestCase):
         self.assertEqual(tester.date,
                          _help_make_datetime('2017-10-23 19:10:25'))
         self.assertEqual(tester.personnel, User('test@foo.bar'))
-        self.assertEqual(tester.process_id, 3)
+        self.assertEqual(tester.process_id, 4)
         exp_plates = [Plate(11), Plate(12), Plate(13), Plate(14),
                       Plate(15), Plate(16), Plate(17), Plate(18)]
         self.assertEqual(tester.primer_set, PrimerSet(1))
@@ -269,11 +269,11 @@ class TestGDNAExtractionProcess(LabmanTestCase):
         self.assertEqual(tester.date,
                          _help_make_datetime('2017-10-25 19:10:25'))
         self.assertEqual(tester.personnel, User('test@foo.bar'))
-        self.assertEqual(tester.process_id, 11)
+        self.assertEqual(tester.process_id, 12)
         self.assertEqual(tester.kingfisher, Equipment(11))
         self.assertEqual(tester.epmotion, Equipment(5))
         self.assertEqual(tester.epmotion_tool, Equipment(15))
-        self.assertEqual(tester.extraction_kit, ReagentComposition(1))
+        self.assertEqual(tester.extraction_kit, ReagentComposition(2))
         self.assertEqual(tester.sample_plate.id, 21)
         self.assertEqual(tester.volume, 10)
         self.assertEqual(tester.notes, None)
@@ -408,7 +408,7 @@ class TestGDNAPlateCompressionProcess(LabmanTestCase):
         self.assertEqual(tester.date,
                          _help_make_datetime('2017-10-25 19:10:25'))
         self.assertEqual(tester.personnel, User('test@foo.bar'))
-        self.assertEqual(tester.process_id, 18)
+        self.assertEqual(tester.process_id, 19)
         self.assertEqual(tester.plates, [Plate(24)])
         self.assertEqual(tester.robot, Equipment(1))
         self.assertEqual(tester.gdna_plates, [Plate(22), Plate(28), Plate(31),
@@ -522,9 +522,9 @@ class TestLibraryPrep16SProcess(LabmanTestCase):
         self.assertEqual(tester.date,
                          _help_make_datetime('2017-10-25 02:10:25'))
         self.assertEqual(tester.personnel, User('test@foo.bar'))
-        self.assertEqual(tester.process_id, 12)
-        self.assertEqual(tester.mastermix, ReagentComposition(2))
-        self.assertEqual(tester.water_lot, ReagentComposition(3))
+        self.assertEqual(tester.process_id, 13)
+        self.assertEqual(tester.mastermix, ReagentComposition(3))
+        self.assertEqual(tester.water_lot, ReagentComposition(4))
         self.assertEqual(tester.epmotion, Equipment(8))
         self.assertEqual(tester.epmotion_tm300_tool, Equipment(16))
         self.assertEqual(tester.epmotion_tm50_tool, Equipment(17))
@@ -604,10 +604,10 @@ class TestNormalizationProcess(LabmanTestCase):
         self.assertEqual(tester.date,
                          _help_make_datetime('2017-10-25 19:10:25'))
         self.assertEqual(tester.personnel, User('test@foo.bar'))
-        self.assertEqual(tester.process_id, 20)
+        self.assertEqual(tester.process_id, 21)
         self.assertEqual(tester.quantification_process,
                          QuantificationProcess(3))
-        self.assertEqual(tester.water_lot, ReagentComposition(3))
+        self.assertEqual(tester.water_lot, ReagentComposition(4))
         exp = {'function': 'default',
                'parameters' : {'total_volume': 3500, 'target_dna': 5,
                                'min_vol': 2.5, 'max_volume': 3500,
@@ -897,7 +897,7 @@ class TestQuantificationProcess(LabmanTestCase):
         self.assertEqual(tester.date,
                          _help_make_datetime('2017-10-25 19:10:05'))
         self.assertEqual(tester.personnel, User('test@foo.bar'))
-        self.assertEqual(tester.process_id, 13)
+        self.assertEqual(tester.process_id, 14)
         self.assertEqual(tester.notes,None)
         obs = tester.concentrations
         # 380 because quantified 4 96-well plates in one process (and each
@@ -914,7 +914,7 @@ class TestQuantificationProcess(LabmanTestCase):
         self.assertEqual(tester.date,
                          _help_make_datetime('2017-10-25 19:10:25'))
         self.assertEqual(tester.personnel, User('test@foo.bar'))
-        self.assertEqual(tester.process_id, 22)
+        self.assertEqual(tester.process_id, 23)
         self.assertEqual(tester.notes,None)
         obs = tester.concentrations
         self.assertEqual(len(obs), 380)
@@ -929,7 +929,7 @@ class TestQuantificationProcess(LabmanTestCase):
         self.assertEqual(tester.date,
                          _help_make_datetime('2017-10-26 03:10:25'))
         self.assertEqual(tester.personnel, User('test@foo.bar'))
-        self.assertEqual(tester.process_id, 26)
+        self.assertEqual(tester.process_id, 27)
         self.assertEqual(tester.notes,"Requantification--oops")
         obs = tester.concentrations
         self.assertEqual(len(obs), 380)
@@ -1009,9 +1009,9 @@ class TestLibraryPrepShotgunProcess(LabmanTestCase):
         self.assertEqual(tester.date,
                          _help_make_datetime('2017-10-25 19:10:25'))
         self.assertEqual(tester.personnel, User('test@foo.bar'))
-        self.assertEqual(tester.process_id, 21)
-        self.assertEqual(tester.kappa_hyper_plus_kit, ReagentComposition(4))
-        self.assertEqual(tester.stub_lot, ReagentComposition(5))
+        self.assertEqual(tester.process_id, 22)
+        self.assertEqual(tester.kappa_hyper_plus_kit, ReagentComposition(5))
+        self.assertEqual(tester.stub_lot, ReagentComposition(6))
         self.assertEqual(tester.normalization_process, NormalizationProcess(1))
         self.assertEqual(tester.normalized_plate, Plate(25))
         self.assertEqual(tester.i5_primer_plate, Plate(19))
@@ -1271,7 +1271,7 @@ class TestPoolingProcess(LabmanTestCase):
         self.assertEqual(tester.date,
                          _help_make_datetime('2017-10-25 19:10:25'))
         self.assertEqual(tester.personnel, User('test@foo.bar'))
-        self.assertEqual(tester.process_id, 15)
+        self.assertEqual(tester.process_id, 16)
         self.assertEqual(tester.quantification_process,
                          QuantificationProcess(1))
         self.assertEqual(tester.robot, Equipment(8))
@@ -1361,7 +1361,7 @@ class TestSequencingProcess(LabmanTestCase):
         self.assertEqual(tester.date,
                          _help_make_datetime('2017-10-25 19:10:25'))
         self.assertEqual(tester.personnel, User('test@foo.bar'))
-        self.assertEqual(tester.process_id, 17)
+        self.assertEqual(tester.process_id, 18)
         self.assertEqual(tester.pools, [[PoolComposition(2), 1]])
         self.assertEqual(tester.run_name, 'Test Run.1')
         self.assertEqual(tester.experiment, 'TestExperiment1')
@@ -1378,7 +1378,7 @@ class TestSequencingProcess(LabmanTestCase):
     def test_list_sequencing_runs(self):
         obs = SequencingProcess.list_sequencing_runs()
 
-        self.assertEqual(obs[0], {'process_id': 17,
+        self.assertEqual(obs[0], {'process_id': 18,
                                   'run_name': 'Test Run.1',
                                   'sequencing_process_id': 1,
                                   'experiment': 'TestExperiment1',
@@ -1387,7 +1387,7 @@ class TestSequencingProcess(LabmanTestCase):
                                   'rev_cycles': 151,
                                   'assay': 'Amplicon',
                                   'principal_investigator': 'test@foo.bar'})
-        self.assertEqual(obs[1], {'process_id': 24,
+        self.assertEqual(obs[1], {'process_id': 25,
                                   'run_name': 'TestShotgunRun1',
                                   'sequencing_process_id': 2,
                                   'experiment': 'TestExperimentShotgun1',
@@ -1678,7 +1678,7 @@ class TestSequencingProcess(LabmanTestCase):
                '[Data]\n'
                'Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,'
                'index,I5_Index_ID,index2,Sample_Project,Well_Description,,\n'
-               'Test_sequencing_pool_1,,,,,NNNNNNNNNNNN,,,,3079,,,')
+               'Test_sequencing_pool_1,,,,,NNNNNNNNNNNN,,,,3080,,,')
         self.assertEqual(obs, exp)
 
         # Amplicon run, multiple lane
@@ -1712,8 +1712,8 @@ class TestSequencingProcess(LabmanTestCase):
                '[Data]\n'
                'Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,'
                'index,I5_Index_ID,index2,Sample_Project,Well_Description,,\n'
-               '1,Test_Pool_from_Plate_1,,,,,NNNNNNNNNNNN,,,,3078,,,\n'
-               '2,Test_sequencing_pool_1,,,,,NNNNNNNNNNNN,,,,3079,,,')
+               '1,Test_Pool_from_Plate_1,,,,,NNNNNNNNNNNN,,,,3079,,,\n'
+               '2,Test_sequencing_pool_1,,,,,NNNNNNNNNNNN,,,,3080,,,')
         self.assertEqual(obs, exp)
 
         # Shotgun run

--- a/labman/gui/handlers/process_handlers/library_prep_shotgun_process.py
+++ b/labman/gui/handlers/process_handlers/library_prep_shotgun_process.py
@@ -75,6 +75,6 @@ class DownloadLibraryPrepShotgunProcessHandler(BaseHandler):
         self.set_header('Expires', '0')
         self.set_header('Cache-Control', 'no-cache')
         self.set_header('Content-Disposition', 'attachment; filename='
-                        'LibraryPrepShotgunSheet_%s.csv' % process_id)
+                        'LibraryPrepShotgunSheet_%s.txt' % process_id)
         self.write(text)
         self.finish()

--- a/labman/gui/handlers/process_handlers/sequencing_process.py
+++ b/labman/gui/handlers/process_handlers/sequencing_process.py
@@ -81,7 +81,7 @@ class DownloadPreparationSheetsHandler(BaseHandler):
             with zipfile.ZipFile(content, mode='w',
                                  compression=zipfile.ZIP_DEFLATED) as zf:
                 for study, prep in process.generate_prep_information().items():
-                    name = 'PrepSheet_process_%s_study_%s.csv' % (process.id,
+                    name = 'PrepSheet_process_%s_study_%s.txt' % (process.id,
                                                                   study.id)
                     zf.writestr(name, prep)
 

--- a/labman/gui/handlers/process_handlers/test/test_library_prep_shotgun_process.py
+++ b/labman/gui/handlers/process_handlers/test/test_library_prep_shotgun_process.py
@@ -50,6 +50,9 @@ class TestDownloadLibraryPrepShotgunProcessHandler(TestHandlerBase):
         self.assertNotEqual(response.body, '')
         self.assertTrue(response.body.startswith(
             b'Sample\tSource Plate Name\t'))
+        self.assertEqual(response.headers['Content-Disposition'],
+                         "attachment; filename=2017-10-25_"
+                        "Test_compressed_gDNA_plates_1-4_input_norm.txt")
 
 
 if __name__ == '__main__':

--- a/labman/gui/handlers/process_handlers/test/test_library_prep_shotgun_process.py
+++ b/labman/gui/handlers/process_handlers/test/test_library_prep_shotgun_process.py
@@ -50,9 +50,6 @@ class TestDownloadLibraryPrepShotgunProcessHandler(TestHandlerBase):
         self.assertNotEqual(response.body, '')
         self.assertTrue(response.body.startswith(
             b'Sample\tSource Plate Name\t'))
-        self.assertEqual(response.headers['Content-Disposition'],
-                         "attachment; filename=2017-10-25_"
-                        "Test_compressed_gDNA_plates_1-4_input_norm.txt")
 
 
 if __name__ == '__main__':

--- a/labman/gui/handlers/process_handlers/test/test_sample_plating_process.py
+++ b/labman/gui/handlers/process_handlers/test/test_sample_plating_process.py
@@ -77,7 +77,7 @@ class TestUtils(TestHandlerBase):
         self.assertEqual(tester.content, 'blank.21.H1')
 
         obs = sample_plating_process_handler_patch_request(
-            self.user, 10, 'replace', '/well/8/1/1/sample', '1.SKM8.640201',
+            self.user, 11, 'replace', '/well/8/1/1/sample', '1.SKM8.640201',
             None)
         self.assertEqual(tester.sample_composition_type, 'experimental sample')
         self.assertEqual(tester.sample_id, '1.SKM8.640201')
@@ -87,7 +87,7 @@ class TestUtils(TestHandlerBase):
                                'sample_ok': True})
 
         obs = sample_plating_process_handler_patch_request(
-            self.user, 10, 'replace', '/well/8/1/1/sample', 'Unknown', None)
+            self.user, 11, 'replace', '/well/8/1/1/sample', 'Unknown', None)
         self.assertEqual(tester.sample_composition_type, 'experimental sample')
         self.assertIsNone(tester.sample_id)
         self.assertEqual(tester.content, 'Unknown')
@@ -96,7 +96,7 @@ class TestUtils(TestHandlerBase):
                                'sample_ok': False})
 
         obs = sample_plating_process_handler_patch_request(
-            self.user, 10, 'replace', '/well/8/1/1/sample', 'blank', None)
+            self.user, 11, 'replace', '/well/8/1/1/sample', 'blank', None)
         self.assertEqual(tester.sample_composition_type, 'blank')
         self.assertIsNone(tester.sample_id)
         self.assertEqual(tester.content, 'blank.21.H1')
@@ -107,10 +107,10 @@ class TestUtils(TestHandlerBase):
         # Test commenting a well
         self.assertIsNone(tester.notes)
         obs = sample_plating_process_handler_patch_request(
-            self.user, 10, 'replace', '/well/8/1/1/notes', 'New Notes', None)
+            self.user, 11, 'replace', '/well/8/1/1/notes', 'New Notes', None)
         self.assertEqual(tester.notes, 'New Notes')
         obs = sample_plating_process_handler_patch_request(
-            self.user, 10, 'replace', '/well/8/1/1/notes', '  ', None)
+            self.user, 11, 'replace', '/well/8/1/1/notes', '  ', None)
         self.assertIsNone(tester.notes)
 
     def test_patch_with_specimen_id(self):
@@ -131,7 +131,7 @@ class TestUtils(TestHandlerBase):
             TRN.add(sql, ['anonymized_name'])
 
             obs = sample_plating_process_handler_patch_request(
-                self.user, 10, 'replace', '/well/8/1/1/sample',
+                self.user, 11, 'replace', '/well/8/1/1/sample',
                 'SKM8', None)
             self.assertEqual(tester.sample_composition_type,
                              'experimental sample')
@@ -143,7 +143,7 @@ class TestUtils(TestHandlerBase):
                                    'sample_ok': True})
 
             obs = sample_plating_process_handler_patch_request(
-                self.user, 10, 'replace', '/well/8/1/1/sample', 'Unknown',
+                self.user, 11, 'replace', '/well/8/1/1/sample', 'Unknown',
                 None)
             self.assertEqual(tester.sample_composition_type,
                              'experimental sample')
@@ -155,7 +155,7 @@ class TestUtils(TestHandlerBase):
                                    'sample_ok': False})
 
             obs = sample_plating_process_handler_patch_request(
-                self.user, 10, 'replace', '/well/8/1/1/sample', 'blank',
+                self.user, 11, 'replace', '/well/8/1/1/sample', 'blank',
                 None)
             self.assertEqual(tester.sample_composition_type, 'blank')
             self.assertIsNone(tester.sample_id)
@@ -168,11 +168,11 @@ class TestUtils(TestHandlerBase):
             # Test commenting a well
             self.assertIsNone(tester.notes)
             obs = sample_plating_process_handler_patch_request(
-                self.user, 10, 'replace', '/well/8/1/1/notes', 'New Notes',
+                self.user, 11, 'replace', '/well/8/1/1/notes', 'New Notes',
                 None)
             self.assertEqual(tester.notes, 'New Notes')
             obs = sample_plating_process_handler_patch_request(
-                self.user, 10, 'replace', '/well/8/1/1/notes', '  ', None)
+                self.user, 11, 'replace', '/well/8/1/1/notes', '  ', None)
             self.assertIsNone(tester.notes)
 
             TRN.add(sql, [None])
@@ -208,7 +208,7 @@ class TestSamplePlatingProcessHandlers(TestHandlerBase):
         obs = SampleComposition(8)
         data = {'op': 'replace', 'path': '/well/8/1/1/sample',
                 'value': '1.SKM8.640201'}
-        response = self.patch('/process/sample_plating/10', data)
+        response = self.patch('/process/sample_plating/11', data)
         self.assertEqual(response.code, 200)
         self.assertEqual(obs.sample_id, '1.SKM8.640201')
         self.assertEqual(json_decode(response.body),
@@ -229,7 +229,7 @@ class TestSamplePlatingProcessHandlers(TestHandlerBase):
             obs = SampleComposition(8)
             data = {'op': 'replace', 'path': '/well/8/1/1/sample',
                     'value': 'SKM8'}
-            response = self.patch('/process/sample_plating/10', data)
+            response = self.patch('/process/sample_plating/11', data)
             self.assertEqual(response.code, 200)
             self.assertEqual(obs.sample_id, '1.SKM8.640201')
             self.assertEqual(obs.specimen_id, 'SKM8')

--- a/labman/gui/handlers/process_handlers/test/test_sequencing_process.py
+++ b/labman/gui/handlers/process_handlers/test/test_sequencing_process.py
@@ -50,7 +50,7 @@ class TestSequencingProcessHandler(TestHandlerBase):
                          'attachment; filename=Test_Run_1_PrepSheets.zip')
 
         archive = zipfile.ZipFile(BytesIO(response.body), 'r')
-        contents = archive.open('PrepSheet_process_1_study_1.csv').read()
+        contents = archive.open('PrepSheet_process_2_study_1.csv').read()
         self.assertNotEqual(contents, '')
 
 

--- a/labman/gui/handlers/process_handlers/test/test_sequencing_process.py
+++ b/labman/gui/handlers/process_handlers/test/test_sequencing_process.py
@@ -50,7 +50,7 @@ class TestSequencingProcessHandler(TestHandlerBase):
                          'attachment; filename=Test_Run_1_PrepSheets.zip')
 
         archive = zipfile.ZipFile(BytesIO(response.body), 'r')
-        contents = archive.open('PrepSheet_process_2_study_1.csv').read()
+        contents = archive.open('PrepSheet_process_1_study_1.csv').read()
         self.assertNotEqual(contents, '')
 
 

--- a/labman/gui/handlers/process_handlers/test/test_sequencing_process.py
+++ b/labman/gui/handlers/process_handlers/test/test_sequencing_process.py
@@ -50,7 +50,7 @@ class TestSequencingProcessHandler(TestHandlerBase):
                          'attachment; filename=Test_Run_1_PrepSheets.zip')
 
         archive = zipfile.ZipFile(BytesIO(response.body), 'r')
-        contents = archive.open('PrepSheet_process_1_study_1.csv').read()
+        contents = archive.open('PrepSheet_process_1_study_1.txt').read()
         self.assertNotEqual(contents, '')
 
 

--- a/labman/gui/templates/compression.html
+++ b/labman/gui/templates/compression.html
@@ -4,7 +4,7 @@
 <link rel="stylesheet" href="/static/vendor/css/jquery-ui.min.css" type="text/css"/>
 <script src="/static/vendor/js/jquery-ui.min.js" type="text/javascript"></script>
 
-<script src="/static/js/plateList.js"></script>
+<script src="/static/js/plateList.js" type="text/javascript"></script>
 
 <script type='text/javascript'>
 

--- a/labman/gui/test/test_plate.py
+++ b/labman/gui/test/test_plate.py
@@ -34,7 +34,7 @@ class TestUtils(TestHandlerBase):
         with self.assertRaisesRegex(HTTPError, regex):
             plate_map_handler_get_request(100)
 
-        obs = plate_map_handler_get_request(10)
+        obs = plate_map_handler_get_request(11)
         exp_plate_confs = [[1, '96-well deep-well plate', 8, 12],
                            [2, '96-well microtiter plate', 8, 12],
                            [3, '384-well microtiter plate', 16, 24]]
@@ -54,7 +54,7 @@ class TestUtils(TestHandlerBase):
                             'Represents an extraction well loaded with Zymo '
                             'Mock community.'}]
         exp = {'plate_confs': exp_plate_confs, 'plate_id': 21,
-               'process_id': 10, 'controls_description': exp_contr_desc}
+               'process_id': 11, 'controls_description': exp_contr_desc}
         self.assertEqual(obs, exp)
 
         obs = plate_map_handler_get_request(None)
@@ -192,7 +192,7 @@ class TestPlateHandlers(TestHandlerBase):
         self.assertEqual(response.code, 200)
         self.assertNotEqual(response.body, '')
 
-        response = self.get('/plate?process_id=10')
+        response = self.get('/plate?process_id=11')
         self.assertEqual(response.code, 200)
         self.assertNotEqual(response.body, '')
 
@@ -690,7 +690,7 @@ class TestPlateHandlers(TestHandlerBase):
         response = self.get('/plate/21/process')
         self.assertEqual(response.code, 200)
         self.assertTrue(
-            response.effective_url.endswith('/plate?process_id=10'))
+            response.effective_url.endswith('/plate?process_id=11'))
 
         response = self.get('/plate/22/process')
         self.assertEqual(response.code, 200)

--- a/labman/gui/test/test_sequence_run.py
+++ b/labman/gui/test/test_sequence_run.py
@@ -19,19 +19,19 @@ class TestSequenceRunListHandler(TestHandlerBase):
 
         self.assertEqual(response.code, 200)
         obs = json_decode(response.body)
-        exp = {'data': [[17,
+        exp = {'data': [[18,
                          'Test Run.1',
                          'TestExperiment1',
                          'Amplicon',
                          'test@foo.bar',
                          1],
-                        [24,
+                        [25,
                          'TestShotgunRun1',
                          'TestExperimentShotgun1',
                          'Metagenomics',
                          'test@foo.bar',
                          2],
-                        [25,
+                        [26,
                          'TestNewRun1',
                          'TestExperimentNew1',
                          'NewKindOfAssay',


### PR DESCRIPTION
TL;DR: Fix for #369 Support "externally extracted" gDNA plates in production-like databases

During real-data testing against labman on qiita-rc, I discovered that the externally extracted gDNA plates functionality did not work because it depend on a number of dummy records in the database, and those records are added in the populate_test_db.sql script--which is not run when a production-like database is created.  This PR moves that functionality out of  populate_test_db.sql 
 and into db_patch_manual.sql--and then updates what-feels-like-zillions of hard-coded process and composition ids in the tests that are affected by having those records created before the test records rather than after them.