### PR TITLE
Added name validation to sample sheet creation

### DIFF
--- a/labman/db/process.py
+++ b/labman/db/process.py
@@ -2917,12 +2917,11 @@ class SequencingProcess(Process):
                 # verify Sample_Name and Sample_Plate here.
                 # Sample_Name = sample
                 # Sample_Plate = sample_plates[i]
-                if re.match("^[a-zA-Z0-9_-]*$", sample):
-                    raise ValueError("Sample names can only contain numbers, \
-                            letters, '_' and '-'")
-                if re.match("^[a-zA-Z0-9_-]*$", sample_plates[i]):
-                    raise ValueError("Sample plate names can only contain \
-                            numbers, letters, '_' and '-'")
+                msg = "may include only '_' and '-' characters"
+                if not re.match("^[a-zA-Z0-9_-]*$", sample):
+                    raise ValueError("sample names %s" % msg)
+                if not re.match("^[a-zA-Z0-9_-]*$", sample_plates[i]):
+                    raise ValueError("sample plate names %s" % msg)
 
                 row = [sample, sample, sample_plates[i], wells[i], i7_name[i],
                        i7_seq[i], i5_name[i], i5_seq[i], sample_projs[i],

--- a/labman/db/process.py
+++ b/labman/db/process.py
@@ -2917,11 +2917,14 @@ class SequencingProcess(Process):
                 # verify Sample_Name and Sample_Plate here.
                 # Sample_Name = sample
                 # Sample_Plate = sample_plates[i]
-                msg = "names may include only '_' and '-' characters"
+                msg1 = "Names may only include alphanumeric characters, "
+                msg1 += "'_',  and '-'."
                 if not re.match("^[a-zA-Z0-9_-]*$", sample):
-                    raise ValueError("'%s' is invalid. Sample %s." % msg)
+                    msg2 = "'%s' is an invalid sample name." % sample
+                    raise ValueError("%s %s" % (msg1, msg2))
                 if not re.match("^[a-zA-Z0-9_-]*$", sample_plates[i]):
-                    raise ValueError("'%s' is invalid. Sample plate %s" % msg)
+                    msg2 = "'%s' is an invalid sample plate name." % sample
+                    raise ValueError("%s %s" % (msg1, msg2))
 
                 row = [sample, sample, sample_plates[i], wells[i], i7_name[i],
                        i7_seq[i], i5_name[i], i5_seq[i], sample_projs[i],

--- a/labman/db/process.py
+++ b/labman/db/process.py
@@ -2919,10 +2919,10 @@ class SequencingProcess(Process):
                 # Sample_Plate = sample_plates[i]
                 msg1 = "Names may only include alphanumeric characters, "
                 msg1 += "'_',  and '-'."
-                if not re.match("^[a-zA-Z0-9_-]*$", sample):
+                if re.match("^[a-zA-Z0-9_-]*$", sample):
                     msg2 = "'%s' is an invalid sample name." % sample
                     raise ValueError("%s %s" % (msg1, msg2))
-                if not re.match("^[a-zA-Z0-9_-]*$", sample_plates[i]):
+                if re.match("^[a-zA-Z0-9_-]*$", sample_plates[i]):
                     msg2 = "'%s' is an invalid sample plate name." % sample
                     raise ValueError("%s %s" % (msg1, msg2))
 

--- a/labman/db/process.py
+++ b/labman/db/process.py
@@ -2917,11 +2917,11 @@ class SequencingProcess(Process):
                 # verify Sample_Name and Sample_Plate here.
                 # Sample_Name = sample
                 # Sample_Plate = sample_plates[i]
-                msg = "may include only '_' and '-' characters"
+                msg = "names may include only '_' and '-' characters"
                 if not re.match("^[a-zA-Z0-9_-]*$", sample):
-                    raise ValueError("sample names %s" % msg)
+                    raise ValueError("'%s' is invalid. Sample %s." % msg)
                 if not re.match("^[a-zA-Z0-9_-]*$", sample_plates[i]):
-                    raise ValueError("sample plate names %s" % msg)
+                    raise ValueError("'%s' is invalid. Sample plate %s" % msg)
 
                 row = [sample, sample, sample_plates[i], wells[i], i7_name[i],
                        i7_seq[i], i5_name[i], i5_seq[i], sample_projs[i],

--- a/labman/db/process.py
+++ b/labman/db/process.py
@@ -2914,16 +2914,6 @@ class SequencingProcess(Process):
         data = []
         for lane in lanes:
             for i, sample in enumerate(sample_ids):
-                # verify Sample_Name and Sample_Plate here.
-                # Sample_Name = sample
-                # Sample_Plate = sample_plates[i]
-                msg = "Names may only include alphanumeric characters, "
-                msg += "'_',  and '-'."
-                if re.match("^[a-zA-Z0-9_-]*$", sample):
-                    raise ValueError(msg)
-                if re.match("^[a-zA-Z0-9_-]*$", sample_plates[i]):
-                    raise ValueError(msg)
-
                 row = [sample, sample, sample_plates[i], wells[i], i7_name[i],
                        i7_seq[i], i5_name[i], i5_seq[i], sample_projs[i],
                        description[i]]
@@ -3109,10 +3099,14 @@ class SequencingProcess(Process):
                     sample_composition.sample_id
                 sample_proj_values.append(self._generate_sample_proj_value(
                     true_sample_id))
-            # Transform the sample ids to be bcl2fastq-compatible
+            # Transform the sample ids and sample plates to be
+            # bcl2fastq-compatible
             bcl2fastq_sample_ids = [
                 SequencingProcess._bcl_scrub_name(sid) for sid in
                 samples_contents]
+            bcl2fastq_sample_plates = [
+                SequencingProcess._bcl_scrub_name(sid) for sid in
+                sample_plates]
             # Reverse the i5 sequences if needed based on the sequencer
             i5_sequences = SequencingProcess._sequencer_i5_index(
                 sequencer_type, i5_sequences)
@@ -3120,9 +3114,9 @@ class SequencingProcess(Process):
             data.append(SequencingProcess._format_sample_sheet_data(
                 bcl2fastq_sample_ids, i7_names, i7_sequences, i5_names,
                 i5_sequences, sample_proj_values, wells=wells,
-                sample_plates=sample_plates, description=samples_contents,
-                lanes=[lane], sep=',', include_header=include_header,
-                include_lane=self.include_lane))
+                sample_plates=bcl2fastq_sample_plates,
+                description=samples_contents, lanes=[lane], sep=',',
+                include_header=include_header, include_lane=self.include_lane))
             include_header = False
 
         data = '\n'.join(data)

--- a/labman/db/process.py
+++ b/labman/db/process.py
@@ -2917,14 +2917,12 @@ class SequencingProcess(Process):
                 # verify Sample_Name and Sample_Plate here.
                 # Sample_Name = sample
                 # Sample_Plate = sample_plates[i]
-                msg1 = "Names may only include alphanumeric characters, "
-                msg1 += "'_',  and '-'."
+                msg = "Names may only include alphanumeric characters, "
+                msg += "'_',  and '-'."
                 if re.match("^[a-zA-Z0-9_-]*$", sample):
-                    msg2 = "'%s' is an invalid sample name." % sample
-                    raise ValueError("%s %s" % (msg1, msg2))
+                    raise ValueError(msg)
                 if re.match("^[a-zA-Z0-9_-]*$", sample_plates[i]):
-                    msg2 = "'%s' is an invalid sample plate name." % sample
-                    raise ValueError("%s %s" % (msg1, msg2))
+                    raise ValueError(msg)
 
                 row = [sample, sample, sample_plates[i], wells[i], i7_name[i],
                        i7_seq[i], i5_name[i], i5_seq[i], sample_projs[i],

--- a/labman/db/process.py
+++ b/labman/db/process.py
@@ -2853,7 +2853,7 @@ class SequencingProcess(Process):
     @staticmethod
     def _format_sample_sheet_data(sample_ids, i7_name, i7_seq, i5_name, i5_seq,
                                   sample_projs, wells=None, sample_plates=None,
-                                  description=None, lanes=[1], sep=',',
+                                  description=None, lanes=None, sep=',',
                                   include_header=True, include_lane=True):
         """Creates the [Data] component of the Illumina sample sheet
 
@@ -2870,9 +2870,13 @@ class SequencingProcess(Process):
         i5_seq: array-like
             The i5 sequences, in sample_ids order
         wells: array-like, optional
-            The source sample wells, in sample_ids order. Default: None
+            The well in which the sample is found on the compressed gDNA plate,
+            in sample_ids order. Default: None
         sample_plate: str, optional
-            The plate name. Default: ''
+            The human-readable *sample* plate name. Default: ''
+            NB: This is NOT the plate that the well, above, is relevant to.
+            This fact is not a bug but rather a user requirement per Greg
+            Humphrey.
         sample_projs: array-like
             The per-sample short project names for use in grouping
             demultiplexed samples
@@ -2907,9 +2911,11 @@ class SequencingProcess(Process):
 
         if wells is None:
             wells = [''] * len(sample_ids)
-
         if description is None:
             description = [''] * len(sample_ids)
+
+        if lanes is None:
+            lanes = [1]
 
         data = []
         for lane in lanes:
@@ -2917,10 +2923,8 @@ class SequencingProcess(Process):
                 row = [sample, sample, sample_plates[i], wells[i], i7_name[i],
                        i7_seq[i], i5_name[i], i5_seq[i], sample_projs[i],
                        description[i]]
-
                 if include_lane:
                     row.insert(0, str(lane))
-
                 data.append(sep.join(row))
 
         data = sorted(data)
@@ -3068,25 +3072,31 @@ class SequencingProcess(Process):
         include_header = True
         for pool, lane in self.pools:
             for component in pool.components:
-                lp_composition = component['composition']
-                # Get the well information
-                well = lp_composition.container
+                libprepshotgun_composition = component['composition']
+                compressed_gdna_composition = libprepshotgun_composition.\
+                    normalized_gdna_composition.compressed_gdna_composition
+                # Get the well of this component ON THE COMPRESSED GDNA PLATE
+                well = compressed_gdna_composition.container
                 wells.append(well.well_id)
-                # Get the plate information
-                sample_plates.append(well.plate.external_id)
+                # Get the human-readable name of the SAMPLE plate from which
+                # this component came
+                sample_composition = compressed_gdna_composition.\
+                    gdna_composition.sample_composition
+                sample_well = sample_composition.container
+                sample_plates.append(sample_well.plate.external_id)
                 # Get the i7 index information
-                i7_comp = lp_composition.i7_composition.primer_set_composition
+                i7_comp = libprepshotgun_composition.\
+                    i7_composition.primer_set_composition
                 i7_names.append(i7_comp.external_id)
                 i7_sequences.append(i7_comp.barcode)
                 # Get the i5 index information
-                i5_comp = lp_composition.i5_composition.primer_set_composition
+                i5_comp = libprepshotgun_composition.\
+                    i5_composition.primer_set_composition
                 i5_names.append(i5_comp.external_id)
                 i5_sequences.append(i5_comp.barcode)
 
                 # Get the sample content (used as description)
-                sample_content = lp_composition.normalized_gdna_composition.\
-                    compressed_gdna_composition.gdna_composition.\
-                    sample_composition.content
+                sample_content = sample_composition.content
                 # sample_content is the labman.sample_composition.content
                 # value, which is the "true" sample_id plus a "." plus the
                 # plate id of the plate on which the sample was plated, plus
@@ -3094,13 +3104,10 @@ class SequencingProcess(Process):
                 # was plated on that plate.
                 samples_contents.append(sample_content)
 
-                true_sample_id = lp_composition.normalized_gdna_composition.\
-                    compressed_gdna_composition.gdna_composition.\
-                    sample_composition.sample_id
+                true_sample_id = sample_composition.sample_id
                 sample_proj_values.append(self._generate_sample_proj_value(
                     true_sample_id))
-            # Transform the sample ids and sample plates to be
-            # bcl2fastq-compatible
+            # Transform the sample ids to be bcl2fastq-compatible
             bcl2fastq_sample_ids = [
                 SequencingProcess._bcl_scrub_name(sid) for sid in
                 samples_contents]

--- a/labman/db/process.py
+++ b/labman/db/process.py
@@ -33,7 +33,7 @@ class Process(base.LabmanObject):
     ----------
     id
     date
-    personnelƒ
+    personnel
     """
 
     @staticmethod

--- a/labman/db/tests/test_process.py
+++ b/labman/db/tests/test_process.py
@@ -1647,7 +1647,7 @@ class TestSequencingProcess(LabmanTestCase):
         obs_sample_sheet = tester2._format_sample_sheet(data, sep='\t')
         self.assertEqual(exp_sample_sheet, obs_sample_sheet)
 
-    def test_generate_sample_sheet(self):
+    def test_generate_sample_sheet_amplicon_single_lane(self):
         # Amplicon run, single lane
         tester = SequencingProcess(1)
         tester_date = datetime.strftime(tester.date, Process.get_date_format())
@@ -1682,6 +1682,7 @@ class TestSequencingProcess(LabmanTestCase):
                'Test_sequencing_pool_1,,,,,NNNNNNNNNNNN,,,,3080,,,')
         self.assertEqual(obs, exp)
 
+    def test_generate_sample_sheet_amplicon_multiple_lane(self):
         # Amplicon run, multiple lane
         user = User('test@foo.bar')
         tester = SequencingProcess.create(
@@ -1717,6 +1718,7 @@ class TestSequencingProcess(LabmanTestCase):
                '2,Test_sequencing_pool_1,,,,,NNNNNNNNNNNN,,,,3080,,,')
         self.assertEqual(obs, exp)
 
+    def test_generate_sample_sheet_shotgun(self):
         # Shotgun run
         tester = SequencingProcess(2)
         tester_date = datetime.strftime(tester.date, Process.get_date_format())
@@ -1747,21 +1749,21 @@ class TestSequencingProcess(LabmanTestCase):
             'Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,'
             'index,I5_Index_ID,index2,Sample_Project,Well_Description',
             '1,1_SKB1_640202_Test_plate_1_A1,1_SKB1_640202_Test_plate_1_A1,'
-            'Test_shotgun_library_plates_1-4,A1,iTru7_101_01,ACGTTACC,'
-            'iTru5_01_A,TTGTCGGT,LabDude_PIDude_1,1.SKB1.640202.'
-            'Test.plate.1.A1']
+            'Test_plate_1,A1,iTru7_101_01,ACGTTACC,iTru5_01_A,'
+            'TTGTCGGT,LabDude_PIDude_1,1.SKB1.640202.Test.plate.1.A1']
         self.assertEqual(obs[:len(exp)], exp)
         exp = ('1,vibrio_positive_control_Test_plate_4_G9,'
                'vibrio_positive_control_Test_plate_4_G9,'
-               'Test_shotgun_library_plates_1-4,N18,iTru7_401_08,CGTAGGTT,'
+               'Test_plate_4,N18,iTru7_401_08,CGTAGGTT,'
                'iTru5_120_F,CATGAGGA,Controls,'
                'vibrio.positive.control.Test.plate.4.G9')
         self.assertEqual(obs[-1], exp)
 
+    def test_generate_sample_sheet_unrecognized_assay_type(self):
         # unrecognized assay type
         tester = SequencingProcess(3)
         with self.assertRaises(ValueError):
-            obs = tester.generate_sample_sheet()
+            tester.generate_sample_sheet()
 
     def test_generate_prep_information(self):
         # Sequencing run

--- a/labman/db/tests/test_process.py
+++ b/labman/db/tests/test_process.py
@@ -1601,7 +1601,7 @@ class TestSequencingProcess(LabmanTestCase):
         sample_ids = ['sample.1', 'sample_1', 'sample-1', 'SAMPLE1']
         sample_plates = ['example1', 'example_1', 'example-1', 'EXAMPLE1']
 
-        exp_err = "Sample names can only contain numbers, letters, '_' and '-'"
+        exp_err = "Names may only include alphanumeric characters, '_',  and '-'."
         with self.assertRaisesRegex(ValueError, exp_err):
             SequencingProcess._format_sample_sheet_data(
                 sample_ids, i7_name, i7_seq, i5_name, i5_seq, sample_projs,
@@ -1611,17 +1611,17 @@ class TestSequencingProcess(LabmanTestCase):
         sample_ids = ['sample1', '$ample1', 'sample-1', 'SAMPLE1']
         sample_plates = ['example1', 'example_1', 'example-1', 'EXAMPLE1']
 
-        exp_err = "Sample names can only contain numbers, letters, '_' and '-'"
+        exp_err = "Names may only include alphanumeric characters, '_',  and '-'."
         with self.assertRaisesRegex(ValueError, exp_err):
             SequencingProcess._format_sample_sheet_data(
                 sample_ids, i7_name, i7_seq, i5_name, i5_seq, sample_projs,
                 wells=wells, sample_plates=sample_plates, lanes=[1])
 
-        # 'sample name' should fail
+        # 'sample three' should fail
         sample_ids = ['sample1', 'sample2', 'sample three', 'SAMPLE1']
         sample_plates = ['example1', 'example_1', 'example-1', 'EXAMPLE1']
 
-        exp_err = "Sample names can only contain numbers, letters, '_' and '-'"
+        exp_err = "Names may only include alphanumeric characters, '_',  and '-'."
         with self.assertRaisesRegex(ValueError, exp_err):
             SequencingProcess._format_sample_sheet_data(
                 sample_ids, i7_name, i7_seq, i5_name, i5_seq, sample_projs,
@@ -1631,7 +1631,7 @@ class TestSequencingProcess(LabmanTestCase):
         sample_ids = ['sample1', 'sample2', 'sample3', 'sample4']
         sample_plates = ['example.1', 'example2', 'example3', 'example4']
 
-        exp_err = "Sample names can only contain numbers, letters, '_' and '-'"
+        exp_err = "Names may only include alphanumeric characters, '_',  and '-'."
         with self.assertRaisesRegex(ValueError, exp_err):
             SequencingProcess._format_sample_sheet_data(
                 sample_ids, i7_name, i7_seq, i5_name, i5_seq, sample_projs,
@@ -1641,7 +1641,7 @@ class TestSequencingProcess(LabmanTestCase):
         sample_ids = ['sample1', 'sample2', 'sample3', 'sample4']
         sample_plates = ['example@1', 'example2', 'example3', 'example4']
 
-        exp_err = "Sample names can only contain numbers, letters, '_' and '-'"
+        exp_err = "Names may only include alphanumeric characters, '_',  and '-'."
         with self.assertRaisesRegex(ValueError, exp_err):
             SequencingProcess._format_sample_sheet_data(
                 sample_ids, i7_name, i7_seq, i5_name, i5_seq, sample_projs,
@@ -1651,7 +1651,7 @@ class TestSequencingProcess(LabmanTestCase):
         sample_ids = ['sample1', 'sample2', 'sample3', 'sample4']
         sample_plates = ['example 1', 'example2', 'example3', 'example4']
 
-        exp_err = "Sample names can only contain numbers, letters, '_' and '-'"
+        exp_err = "Names may only include alphanumeric characters, '_',  and '-'."
         with self.assertRaisesRegex(ValueError, exp_err):
             SequencingProcess._format_sample_sheet_data(
                 sample_ids, i7_name, i7_seq, i5_name, i5_seq, sample_projs,

--- a/labman/db/tests/test_process.py
+++ b/labman/db/tests/test_process.py
@@ -1570,6 +1570,9 @@ class TestSequencingProcess(LabmanTestCase):
         self.assertEqual(obs_data, exp_data)
 
     def test_format_sample_sheet_data_name_validation(self):
+        #setting maxDiff to none allows test to report large non-equal strings 
+        self.maxDiff = None
+
         # test that single lane works
         exp_data = (
             'Lane,Sample_ID,Sample_Name,Sample_Plate'
@@ -1593,15 +1596,6 @@ class TestSequencingProcess(LabmanTestCase):
         i7_name = ['iTru7_101_01', 'iTru7_101_02',
                    'iTru7_101_03', 'iTru7_101_04']
         i7_seq = ['ACGTTACC', 'CTGTGTTG', 'TGAGGTGT', 'GATCCATG']
-
-        # all valid sample ids - these should raise no ValueErrors
-        sample_ids = ['sample1', 'sample_1', 'sample-1', 'SAMPLE1']
-        sample_plates = ['example1', 'example_1', 'example-1', 'EXAMPLE1']
-
-        obs_data = SequencingProcess._format_sample_sheet_data(
-            sample_ids, i7_name, i7_seq, i5_name, i5_seq, sample_projs,
-            wells=wells, sample_plates=sample_plates, lanes=[1])
-        self.assertEqual(obs_data, exp_data)
 
         # sample.1 should fail
         sample_ids = ['sample.1', 'sample_1', 'sample-1', 'SAMPLE1']

--- a/labman/db/tests/test_process.py
+++ b/labman/db/tests/test_process.py
@@ -1573,21 +1573,36 @@ class TestSequencingProcess(LabmanTestCase):
         # setting maxDiff to none allows test to report large non-equal strings
         self.maxDiff = None
 
+        """
+        Expected transformations:
+            sample.1 -> sample_1
+            $sample 2 -> _sample_2
+            sample-3 -> sample-3
+            sample_4 -> sample_4
+
+            example.1 -> example_1
+            exaMple* 2 -> exaMple__2
+            example-3 -> example-3
+            example_4 -> example_4
+        """
+
         # test that single lane works
         exp_data = (
             'Lane,Sample_ID,Sample_Name,Sample_Plate'
             ',Sample_Well,I7_Index_ID,index,I5_Index_ID'
             ',index2,Sample_Project,Well_Description\n'
-            '1,blank1,blank1,example,B1,iTru7_101_03,TGAGGTGT,'
+            '1,sample_1,sample_1,example_1,B1,iTru7_101_03,TGAGGTGT,'
             'iTru5_01_C,CACAGACT,,\n'
-            '1,sam1,sam1,example,A1,iTru7_101_01,ACGTTACC,'
+            '1,sample_2,_sample_2,exaMple__2,A1,iTru7_101_01,ACGTTACC,'
             'iTru5_01_A,ACCGACAA,labperson1_pi1_studyId1,\n'
-            '1,sam2,sam2,example,A2,iTru7_101_02,CTGTGTTG,'
+            '1,sample-3,sample-3,example-3,A2,iTru7_101_02,CTGTGTTG,'
             'iTru5_01_B,AGTGGCAA,labperson1_pi1_studyId1,\n'
-            '1,sam3,sam3,example,B2,iTru7_101_04,GATCCATG,'
+            '1,sample_4,sample_4,example_4,B2,iTru7_101_04,GATCCATG,'
             'iTru5_01_D,CGACACTT,labperson1_pi1_studyId1,'
         )
 
+        sample_ids = ['sample.1', '$sample 2', 'sample-3', 'sample_4']
+        sample_plates = ['example.1', 'exaMple* 2', 'example-3', 'example_4']
         wells = ['A1', 'A2', 'B1', 'B2']
         sample_projs = ["labperson1_pi1_studyId1", "labperson1_pi1_studyId1",
                         "", "labperson1_pi1_studyId1"]
@@ -1597,64 +1612,11 @@ class TestSequencingProcess(LabmanTestCase):
                    'iTru7_101_03', 'iTru7_101_04']
         i7_seq = ['ACGTTACC', 'CTGTGTTG', 'TGAGGTGT', 'GATCCATG']
 
-        # sample.1 should fail
-        sample_ids = ['sample.1', 'sample_1', 'sample-1', 'SAMPLE1',
-                      'sample1', '$ample1', 'sample2', 'sample three']
-        sample_plates = ['example1', 'example_1', 'example-1', 'EXAMPLE1']
-
         obs_data = SequencingProcess._format_sample_sheet_data(
                 sample_ids, i7_name, i7_seq, i5_name, i5_seq, sample_projs,
                 wells=wells, sample_plates=sample_plates, lanes=[1])
 
-        # $ample1 should fail
-        sample_ids = ['sample1', '$ample1', 'sample-1', 'SAMPLE1']
-        sample_plates = ['example1', 'example_1', 'example-1', 'EXAMPLE1']
-
-        exp_err = "Names may only include alphanumeric characters, '_',  and '-'."
-        with self.assertRaisesRegex(ValueError, exp_err):
-            SequencingProcess._format_sample_sheet_data(
-                sample_ids, i7_name, i7_seq, i5_name, i5_seq, sample_projs,
-                wells=wells, sample_plates=sample_plates, lanes=[1])
-
-        # 'sample three' should fail
-        sample_ids = ['sample1', 'sample2', 'sample three', 'SAMPLE1']
-        sample_plates = ['example1', 'example_1', 'example-1', 'EXAMPLE1']
-
-        exp_err = "Names may only include alphanumeric characters, '_',  and '-'."
-        with self.assertRaisesRegex(ValueError, exp_err):
-            SequencingProcess._format_sample_sheet_data(
-                sample_ids, i7_name, i7_seq, i5_name, i5_seq, sample_projs,
-                wells=wells, sample_plates=sample_plates, lanes=[1])
-
-        # example.1 should fail
-        sample_ids = ['sample1', 'sample2', 'sample3', 'sample4']
-        sample_plates = ['example.1', 'example2', 'example3', 'example4']
-
-        exp_err = "Names may only include alphanumeric characters, '_',  and '-'."
-        with self.assertRaisesRegex(ValueError, exp_err):
-            SequencingProcess._format_sample_sheet_data(
-                sample_ids, i7_name, i7_seq, i5_name, i5_seq, sample_projs,
-                wells=wells, sample_plates=sample_plates, lanes=[1])
-
-        # example@1 should fail
-        sample_ids = ['sample1', 'sample2', 'sample3', 'sample4']
-        sample_plates = ['example@1', 'example2', 'example3', 'example4']
-
-        exp_err = "Names may only include alphanumeric characters, '_',  and '-'."
-        with self.assertRaisesRegex(ValueError, exp_err):
-            SequencingProcess._format_sample_sheet_data(
-                sample_ids, i7_name, i7_seq, i5_name, i5_seq, sample_projs,
-                wells=wells, sample_plates=sample_plates, lanes=[1])
-
-        # 'example 1' should fail
-        sample_ids = ['sample1', 'sample2', 'sample3', 'sample4']
-        sample_plates = ['example 1', 'example2', 'example3', 'example4']
-
-        exp_err = "Names may only include alphanumeric characters, '_',  and '-'."
-        with self.assertRaisesRegex(ValueError, exp_err):
-            SequencingProcess._format_sample_sheet_data(
-                sample_ids, i7_name, i7_seq, i5_name, i5_seq, sample_projs,
-                wells=wells, sample_plates=sample_plates, lanes=[1])
+        self.assertEqual(obs_data, exp_data)
 
     def test_format_sample_sheet_comments(self):
         contacts = {'Test User': 'tuser@fake.com',

--- a/labman/db/tests/test_process.py
+++ b/labman/db/tests/test_process.py
@@ -1570,7 +1570,7 @@ class TestSequencingProcess(LabmanTestCase):
         self.assertEqual(obs_data, exp_data)
 
     def test_format_sample_sheet_data_name_validation(self):
-        #setting maxDiff to none allows test to report large non-equal strings 
+        # setting maxDiff to none allows test to report large non-equal strings
         self.maxDiff = None
 
         # test that single lane works
@@ -1598,12 +1598,11 @@ class TestSequencingProcess(LabmanTestCase):
         i7_seq = ['ACGTTACC', 'CTGTGTTG', 'TGAGGTGT', 'GATCCATG']
 
         # sample.1 should fail
-        sample_ids = ['sample.1', 'sample_1', 'sample-1', 'SAMPLE1']
+        sample_ids = ['sample.1', 'sample_1', 'sample-1', 'SAMPLE1',
+                      'sample1', '$ample1', 'sample2', 'sample three']
         sample_plates = ['example1', 'example_1', 'example-1', 'EXAMPLE1']
 
-        exp_err = "Names may only include alphanumeric characters, '_',  and '-'."
-        with self.assertRaisesRegex(ValueError, exp_err):
-            SequencingProcess._format_sample_sheet_data(
+        obs_data = SequencingProcess._format_sample_sheet_data(
                 sample_ids, i7_name, i7_seq, i5_name, i5_seq, sample_projs,
                 wells=wells, sample_plates=sample_plates, lanes=[1])
 
@@ -1835,12 +1834,13 @@ class TestSequencingProcess(LabmanTestCase):
             'Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,'
             'index,I5_Index_ID,index2,Sample_Project,Well_Description',
             '1,1_SKB1_640202_Test_plate_1_A1,1_SKB1_640202_Test_plate_1_A1,'
-            'Test shotgun library plates 1-4,A1,iTru7_101_01,ACGTTACC,iTru5_01_A,'
-            'TTGTCGGT,LabDude_PIDude_1,1.SKB1.640202.Test.plate.1.A1']
+            'Test_shotgun_library_plates_1-4,A1,iTru7_101_01,ACGTTACC,'
+            'iTru5_01_A,TTGTCGGT,LabDude_PIDude_1,1.SKB1.640202.'
+            'Test.plate.1.A1']
         self.assertEqual(obs[:len(exp)], exp)
         exp = ('1,vibrio_positive_control_Test_plate_4_G9,'
                'vibrio_positive_control_Test_plate_4_G9,'
-               'Test shotgun library plates 1-4,N18,iTru7_401_08,CGTAGGTT,'
+               'Test_shotgun_library_plates_1-4,N18,iTru7_401_08,CGTAGGTT,'
                'iTru5_120_F,CATGAGGA,Controls,'
                'vibrio.positive.control.Test.plate.4.G9')
         self.assertEqual(obs[-1], exp)

--- a/labman/db/tests/test_process.py
+++ b/labman/db/tests/test_process.py
@@ -1569,55 +1569,6 @@ class TestSequencingProcess(LabmanTestCase):
             include_lane=False)
         self.assertEqual(obs_data, exp_data)
 
-    def test_format_sample_sheet_data_name_validation(self):
-        # setting maxDiff to none allows test to report large non-equal strings
-        self.maxDiff = None
-
-        """
-        Expected transformations:
-            sample.1 -> sample_1
-            $sample 2 -> _sample_2
-            sample-3 -> sample-3
-            sample_4 -> sample_4
-
-            example.1 -> example_1
-            exaMple* 2 -> exaMple__2
-            example-3 -> example-3
-            example_4 -> example_4
-        """
-
-        # test that single lane works
-        exp_data = (
-            'Lane,Sample_ID,Sample_Name,Sample_Plate'
-            ',Sample_Well,I7_Index_ID,index,I5_Index_ID'
-            ',index2,Sample_Project,Well_Description\n'
-            '1,sample_1,sample_1,example_1,B1,iTru7_101_03,TGAGGTGT,'
-            'iTru5_01_C,CACAGACT,,\n'
-            '1,sample_2,_sample_2,exaMple__2,A1,iTru7_101_01,ACGTTACC,'
-            'iTru5_01_A,ACCGACAA,labperson1_pi1_studyId1,\n'
-            '1,sample-3,sample-3,example-3,A2,iTru7_101_02,CTGTGTTG,'
-            'iTru5_01_B,AGTGGCAA,labperson1_pi1_studyId1,\n'
-            '1,sample_4,sample_4,example_4,B2,iTru7_101_04,GATCCATG,'
-            'iTru5_01_D,CGACACTT,labperson1_pi1_studyId1,'
-        )
-
-        sample_ids = ['sample.1', '$sample 2', 'sample-3', 'sample_4']
-        sample_plates = ['example.1', 'exaMple* 2', 'example-3', 'example_4']
-        wells = ['A1', 'A2', 'B1', 'B2']
-        sample_projs = ["labperson1_pi1_studyId1", "labperson1_pi1_studyId1",
-                        "", "labperson1_pi1_studyId1"]
-        i5_name = ['iTru5_01_A', 'iTru5_01_B', 'iTru5_01_C', 'iTru5_01_D']
-        i5_seq = ['ACCGACAA', 'AGTGGCAA', 'CACAGACT', 'CGACACTT']
-        i7_name = ['iTru7_101_01', 'iTru7_101_02',
-                   'iTru7_101_03', 'iTru7_101_04']
-        i7_seq = ['ACGTTACC', 'CTGTGTTG', 'TGAGGTGT', 'GATCCATG']
-
-        obs_data = SequencingProcess._format_sample_sheet_data(
-                sample_ids, i7_name, i7_seq, i5_name, i5_seq, sample_projs,
-                wells=wells, sample_plates=sample_plates, lanes=[1])
-
-        self.assertEqual(obs_data, exp_data)
-
     def test_format_sample_sheet_comments(self):
         contacts = {'Test User': 'tuser@fake.com',
                     'Another User': 'anuser@fake.com',


### PR DESCRIPTION
sample names and sample plate names must now contain only alphanumeric
characters, '_', and '-', when creating a new sample sheet. This commit
duplicates earlier commit to private fork.