### PR TITLE
fix #364

### DIFF
--- a/labman/db/tests/test_util.py
+++ b/labman/db/tests/test_util.py
@@ -1,0 +1,27 @@
+# ----------------------------------------------------------------------------
+# Copyright (c) 2017-, labman development team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file LICENSE, distributed with this software.
+# ----------------------------------------------------------------------------
+
+from unittest import main
+
+from labman.db.testing import LabmanTestCase
+
+from labman.db.composition import PoolComposition
+from labman.db.util import get_pools_listing
+
+
+class TestUtil(LabmanTestCase):
+    def test_get_pools_listing(self):
+        exp = [[p.id, p.container.external_id,
+                p.is_plate_pool, p.upstream_process.id]
+               for p in PoolComposition.get_pools()]
+        obs = get_pools_listing()
+        self.assertEqual(obs, exp)
+
+
+if __name__ == '__main__':
+    main()

--- a/labman/db/util.py
+++ b/labman/db/util.py
@@ -16,6 +16,13 @@ def get_pools_listing():
     Returns
     -------
     list of list
+
+    Notes
+    -----
+    Reproduces the functionality of:
+    [p.id, p.container.external_id, p.is_plate_pool, p.upstream_process.id]
+     for p in PoolComposition.get_pools()]
+    but with direct calls to the database
     """
     with sql_connection.TRN as TRN:
         sql = """SELECT pool_composition_id, external_id,

--- a/labman/db/util.py
+++ b/labman/db/util.py
@@ -1,0 +1,44 @@
+# ----------------------------------------------------------------------------
+# Copyright (c) 2017-, labman development team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file LICENSE, distributed with this software.
+# ----------------------------------------------------------------------------
+
+from . import sql_connection
+from . import process
+
+
+def get_pools_listing():
+    """Generates pool listing for GUI with direct DB access for speed
+
+    Returns
+    -------
+    list of list
+    """
+    with sql_connection.TRN as TRN:
+        sql = """SELECT pool_composition_id, external_id,
+                    (SELECT DISTINCT description != 'pool'
+                     FROM labman.pool_composition_components
+                     LEFT JOIN labman.composition ON (
+                         input_composition_id = composition_iD)
+                     LEFT JOIN labman.composition_type USING (
+                         composition_type_id)
+                     WHERE output_pool_composition_id = pool_composition_id)
+                     as is_plate_pool, upstream_process_id
+                 FROM labman.pool_composition
+                 LEFT JOIN labman.composition USING (composition_id)
+                 LEFT JOIN labman.tube USING (container_id)
+                 LEFT JOIN labman.composition_type USING (composition_type_id)
+                 ORDER BY pool_composition_id"""
+        TRN.add(sql)
+
+        # if you are looking for a way to improve performance, you would
+        # need to:
+        # 1. Create a database table with all the process.Process.factory
+        # factory_classes
+        # 2. retrieve the table names that corresponde to each object
+        # 3. reproduce what process.Process.factory does but in the database
+        return [[pid, eid, ipp, process.Process.factory(upi).id]
+                for pid, eid, ipp, upi in TRN.execute_fetchindex()]

--- a/labman/gui/handlers/pool.py
+++ b/labman/gui/handlers/pool.py
@@ -9,6 +9,7 @@
 from tornado.web import authenticated, HTTPError
 
 from labman.gui.handlers.base import BaseHandler
+from labman.db.util import get_pools_listing
 from labman.db.composition import PoolComposition
 from labman.db.exceptions import LabmanUnknownIdError
 
@@ -22,11 +23,7 @@ class PoolListingHandler(BaseHandler):
 class PoolListHandler(BaseHandler):
     @authenticated
     def get(self):
-        res = {"data": [
-            [p.id, p.container.external_id, p.is_plate_pool,
-             p.upstream_process.id, ]
-            for p in PoolComposition.get_pools()
-        ]}
+        res = {"data": get_pools_listing()}
         self.write(res)
 
 

--- a/labman/gui/templates/pool_list.html
+++ b/labman/gui/templates/pool_list.html
@@ -7,7 +7,8 @@
     var table = $('#poolListTable').DataTable(
       {'columnDefs': [{'targets': 0, 'orderable': false, 'width': '30px'}],
        'order': [[1, "desc"]],
-       'language': {'zeroRecords': 'No pools found'}});
+       'language': {'zeroRecords': 'Loading records, please wait ...'}});
+
     $.get('/pool_list', function(data) {
       var datatable = $('#poolListTable').DataTable();
       var newData = [];
@@ -24,6 +25,7 @@
       }
       datatable.clear();
       datatable.rows.add(newData);
+      datatable.settings()[0].oLanguage['sZeroRecords'] = 'No pools found!';
       datatable.draw();
       $('.table-checkbox').on('change', function() {
         if (this.checked) {


### PR DESCRIPTION
To fix #364 I decided to go two ways:
1. Add a message in the GUI so it's clear/visible that we are waiting for the list to be displayed.![example](https://user-images.githubusercontent.com/2014559/55834441-34187f80-5ad7-11e9-8a06-6625a158236b.gif)
2. Speed up the listing via an improved query, this means that I created a new file db.util where we should store all these improvements from now on. To better reproduce the issue I added a few pools (total 94). With these, the original method takes `7.57 s ± 44.1 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)`, while the new added method takes `134 ms ± 1.6 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)`. Note that there is still room for performance improvement but that will take multiple changes; explained as a comment in the method so based on the time it will take to make these changes and the current performance improvement, I decided to not solve and not add an issue. Once we get to 1000s of pools we can address. 