### PR TITLE
WIP: Clarify icon meaning (#304)

### DIFF
--- a/labcontrol/gui/static/js/labman.js
+++ b/labcontrol/gui/static/js/labman.js
@@ -144,10 +144,17 @@ function onKeyUpPlateName(e, input, checksCallback, successCallback) {
   // Check if the new value is the empty string
   var value = $('#' + input).val().trim()
   var $div = $('#' + input).closest('div');
+
+  if (value === '') {
+      $div.removeClass('has-success').addClass('has-error').find('span').removeClass('glyphicon-ok').addClass('glyphicon-remove');
+      $('#newNameDivMessage').text('No name specified');
+  }
+
   if (value !== '') {
     $.get('/platename?new-name=' + value, function (data) {
       // If we get here it means that the name already exists
       $div.removeClass('has-success').addClass('has-error').find('span').removeClass('glyphicon-ok').addClass('glyphicon-remove');
+      $('#newNameDivMessage').text('Name is already used');
       // $('#updateNameBtn').prop('disabled', true);
       checksCallback();
     })
@@ -156,6 +163,7 @@ function onKeyUpPlateName(e, input, checksCallback, successCallback) {
         if(jqXHR.status === 404) {
           // The plate name doesn't exist - it is ok to change to this name
           $div.removeClass('has-error').addClass('has-success').find('span').removeClass('glyphicon-remove').addClass('glyphicon-ok');
+          $('#newNameDivMessage').text('Name is available');
           // $('#updateNameBtn').prop('disabled', false);
           checksCallback();
           if(e.which == 13 && successCallback !== undefined) {

--- a/labcontrol/gui/templates/plate.html
+++ b/labcontrol/gui/templates/plate.html
@@ -33,6 +33,7 @@
       $('#newNameInput').focus().prop('disabled', false).val('');
       $('#updateNameBtn').prop('disabled', true).find('span').removeClass('glyphicon glyphicon-refresh gly-spin');
       $('#newNameDiv').removeClass('has-success').addClass('has-error').find('span').removeClass('glyphicon-ok').addClass('glyphicon-remove');
+
       var pId = $('#plateName').prop('pm-data-plate-id');
       if (pId !== undefined) {
         // The user is modifying an existing plate - do not force the user
@@ -175,6 +176,7 @@
           <label for='newNameInput'>New name:</label>
           <input type='text' class='form-control' id='newNameInput'>
           <span class='glyphicon glyphicon-remove form-control-feedback'></span>
+          <p id='newNameDivMessage'>No name specified</p>
         </div>
       </div>
       <div class='modal-footer'>


### PR DESCRIPTION
Before working through the rest of th to resolve #304, does this type modification work? It adds a human readable message about the status in addition to color and icon. For some pages, the strategy may need to differ. 

![improve-icon-clarity](https://user-images.githubusercontent.com/474290/56326561-5770a980-612b-11e9-8ee5-0bef132ea4b3.gif)
