### PR TITLE
Issue420

### DIFF
--- a/labcontrol/db/composition.py
+++ b/labcontrol/db/composition.py
@@ -91,6 +91,10 @@ class Composition(base.LabControlObject):
             composition_id = TRN.execute_fetchlast()
         return composition_id
 
+    @classmethod
+    def get_composition_type_description(cls):
+        return cls._composition_type
+
     def _get_composition_attr(self, attr):
         """Returns the value of the given composition attribute
 
@@ -1163,19 +1167,6 @@ class PoolComposition(Composition):
             TRN.add(sql, [self.composition_id])
             res = TRN.execute_fetchindex()
             return res[0][0] if res else None
-
-    @property
-    def is_plate_pool(self):
-        """Return True if pool components are PoolCompositions, else False
-
-        Returns
-        -------
-        True if pool components are PoolCompositions, else False
-        """
-        composition_components = [x["composition"] for x in self.components]
-        component_type = self.get_components_type(composition_components)
-        result = component_type != PoolComposition
-        return result
 
 
 class PrimerSet(base.LabControlObject):

--- a/labcontrol/db/tests/test_composition.py
+++ b/labcontrol/db/tests/test_composition.py
@@ -83,6 +83,10 @@ class TestsComposition(LabControlTestCase):
         self.assertEqual(obs.reagent_type, 'extraction kit')
         self.assertIsNone(obs.study)
 
+    def test_reagent_composition_get_composition_type_description(self):
+        obs = ReagentComposition(2)
+        self.assertEqual(obs.get_composition_type_description(), "reagent")
+
     def test_primer_composition_attributes(self):
         obs = PrimerComposition(1)
         self.assertEqual(obs.container, Well(1537))
@@ -99,6 +103,10 @@ class TestsComposition(LabControlTestCase):
         self.assertEqual(obs.primer_set_composition, PrimerSetComposition(1))
         self.assertIsNone(obs.study)
 
+    def test_primer_composition_get_composition_type_description(self):
+        obs = PrimerComposition(1)
+        self.assertEqual(obs.get_composition_type_description(), "primer")
+
     def test_primer_set_composition_attributes(self):
         obs = PrimerSetComposition(1)
         self.assertEqual(obs.container, Well(1))
@@ -107,6 +115,10 @@ class TestsComposition(LabControlTestCase):
         self.assertEqual(obs.composition_id, 1)
         self.assertEqual(obs.barcode, 'AGCCTTCGTCGC')
         self.assertIsNone(obs.study)
+
+    def test_primer_set_composition_get_composition_type_description(self):
+        obs = PrimerSetComposition(1)
+        self.assertEqual(obs.get_composition_type_description(), "primer set")
 
     def test_sample_composition_get_control_samples(self):
         self.assertEqual(
@@ -195,6 +207,14 @@ class TestsComposition(LabControlTestCase):
         self.assertIsNone(obs.notes)
         self.assertEqual(obs.composition_id, 3124)
         self.assertIsNone(obs.study)
+
+    def test_sample_composition_get_composition_type_description(self):
+        # NB: All sample compositions have generic composition type "sample",
+        # even if they are controls. For details of what kind of "sample" they
+        # are, look at the external id of the individual
+        # sample_composition_type records.
+        obs = SampleComposition(8)
+        self.assertEqual(obs.get_composition_type_description(), "sample")
 
     def test_sample_composition_get_sample_composition_type_id(self):
         self.assertEqual(
@@ -287,6 +307,10 @@ class TestsComposition(LabControlTestCase):
         self.assertEqual(obs.composition_id, 3083)
         self.assertEqual(obs.study, Study(1))
 
+    def test_gdna_composition_get_composition_type_description(self):
+        obs = GDNAComposition(1)
+        self.assertEqual(obs.get_composition_type_description(), "gDNA")
+
     def test_library_prep_16S_composition_attributes(self):
         obs = LibraryPrep16SComposition(1)
         self.assertEqual(obs.container, Well(3075))
@@ -297,12 +321,24 @@ class TestsComposition(LabControlTestCase):
         self.assertEqual(obs.composition_id, 3084)
         self.assertEqual(obs.study, Study(1))
 
+    def test_library_prep_16S_composition_get_composition_type_description(
+            self):
+        obs = LibraryPrep16SComposition(1)
+        self.assertEqual(obs.get_composition_type_description(),
+                         "16S library prep")
+
     def test_compressed_gDNA_composition_attributes(self):
         obs = CompressedGDNAComposition(1)
         self.assertEqual(obs.container, Well(3076))
         self.assertEqual(obs.total_volume, 10)
         self.assertIsNone(obs.notes)
         self.assertEqual(obs.gdna_composition, GDNAComposition(1))
+
+    def test_compressed_gdna_composition_get_composition_type_description(
+            self):
+        obs = CompressedGDNAComposition(1)
+        self.assertEqual(obs.get_composition_type_description(),
+                         "compressed gDNA")
 
     def test_normalized_gDNA_composition_attributes(self):
         obs = NormalizedGDNAComposition(1)
@@ -316,6 +352,12 @@ class TestsComposition(LabControlTestCase):
         self.assertEqual(obs.composition_id, 3086)
         self.assertEqual(obs.study, Study(1))
 
+    def test_normalized_gdna_composition_get_composition_type_description(
+            self):
+        obs = NormalizedGDNAComposition(1)
+        self.assertEqual(obs.get_composition_type_description(),
+                         "normalized gDNA")
+
     def test_library_prep_shotgun_composition_attributes(self):
         obs = LibraryPrepShotgunComposition(1)
         self.assertEqual(obs.container, Well(3078))
@@ -327,6 +369,12 @@ class TestsComposition(LabControlTestCase):
         self.assertEqual(obs.i7_composition, PrimerComposition(770))
         self.assertEqual(obs.composition_id, 3087)
         self.assertEqual(obs.study, Study(1))
+
+    def test_library_prep_shotgun_composition_get_composition_type_description(
+            self):
+        obs = LibraryPrepShotgunComposition(1)
+        self.assertEqual(obs.get_composition_type_description(),
+                         "shotgun library prep")
 
     def test_pool_composition_get_components_type_multiple_raises(self):
         with self.assertRaises(ValueError):
@@ -359,13 +407,9 @@ class TestsComposition(LabControlTestCase):
         self.assertEqual(obs_comp[0], exp)
         self.assertEqual(obs.raw_concentration, 25.0)
 
-    def test_pool_composition_attributes_is_plate_pool(self):
-        obs1 = PoolComposition(1)  # of 16s
-        self.assertTrue(obs1.is_plate_pool)
-        obs2 = PoolComposition(2)  # of pools
-        self.assertFalse(obs2.is_plate_pool)
-        obs3 = PoolComposition(3)  # of shotgun
-        self.assertTrue(obs3.is_plate_pool)
+    def test_pool_composition_get_composition_type_description(self):
+        obs = PoolComposition(1)
+        self.assertEqual(obs.get_composition_type_description(), "pool")
 
     def test_primer_set_attributes(self):
         obs = PrimerSet(1)

--- a/labcontrol/db/tests/test_util.py
+++ b/labcontrol/db/tests/test_util.py
@@ -15,11 +15,56 @@ from labcontrol.db.util import get_pools_listing
 
 
 class TestUtil(LabControlTestCase):
-    def test_get_pools_listing(self):
-        exp = [[p.id, p.container.external_id,
-                p.is_plate_pool, p.upstream_process.id]
-               for p in PoolComposition.get_pools()]
-        obs = get_pools_listing()
+    def test_get_pools_listing_all(self):
+        exp = [
+            # This is an amplicon plate pool, so
+            # True for is_plate_pool and True for is_amplicon_plate_pool
+            [1, 'Test Pool from Plate 1', True, True, 1],
+            # This is an amplicon sequencing pool, so
+            # False for is_plate_pool and False for is_amplicon_plate_pool (bc
+            # is actually pool of pools, not pool of amplicon preps)
+            [2, 'Test sequencing pool 1', False, False, 2],
+            # This is a *shotgun* plate pool, so
+            # True for is plate pool but False for is_amplicon_plate_pool
+            [3, 'Test pool from Shotgun plates 1-4', True, False, 3],
+            # These are amplicon plate pools
+            [4, 'Test Pool from Plate 2', True, True, 4],
+            [5, 'Test Pool from Plate 3', True, True, 5],
+            [6, 'Test Pool from Plate 4', True, True, 6]
+        ]
+        obs = get_pools_listing([True, False], [True, False])
+        self.assertEqual(obs, exp)
+
+    def test_get_pools_listing_amplicon_plate_pool_only(self):
+        exp = [
+            # This is an amplicon plate pool, so
+            # True for is_plate_pool and True for is_amplicon_plate_pool
+            [1, 'Test Pool from Plate 1', True, True, 1],
+            # These are amplicon plate pools
+            [4, 'Test Pool from Plate 2', True, True, 4],
+            [5, 'Test Pool from Plate 3', True, True, 5],
+            [6, 'Test Pool from Plate 4', True, True, 6]
+        ]
+        obs = get_pools_listing([True], [True])
+        self.assertEqual(obs, exp)
+
+    def test_get_pools_listing_amplicon_sequencing_pool_only(self):
+        exp = [
+            # This is an amplicon sequencing pool, so
+            # False for is_plate_pool and False for is_amplicon_plate_pool (bc
+            # is actually pool of pools, not pool of amplicon preps)
+            [2, 'Test sequencing pool 1', False, False, 2]
+        ]
+        obs = get_pools_listing([False], [False])
+        self.assertEqual(obs, exp)
+
+    def test_get_pools_listing_metagenomics_plate_pool(self):
+        exp = [
+            # This is a *shotgun* plate pool, so
+            # True for is plate pool but False for is_amplicon_plate_pool
+            [3, 'Test pool from Shotgun plates 1-4', True, False, 3]
+        ]
+        obs = get_pools_listing([True], [False])
         self.assertEqual(obs, exp)
 
 

--- a/labcontrol/db/tests/test_util.py
+++ b/labcontrol/db/tests/test_util.py
@@ -58,7 +58,7 @@ class TestUtil(LabControlTestCase):
         obs = get_pools_listing([False], [False])
         self.assertEqual(obs, exp)
 
-    def test_get_pools_listing_metagenomics_plate_pool(self):
+    def test_get_pools_listing_shotgun_plate_pool(self):
         exp = [
             # This is a *shotgun* plate pool, so
             # True for is plate pool but False for is_amplicon_plate_pool

--- a/labcontrol/db/util.py
+++ b/labcontrol/db/util.py
@@ -8,9 +8,10 @@
 
 from . import sql_connection
 from . import process
+from . import composition
 
 
-def get_pools_listing():
+def get_pools_listing(is_plate_pool_limits, is_amplicon_plate_pool_limits):
     """Generates pool listing for GUI with direct DB access for speed
 
     Returns
@@ -19,33 +20,48 @@ def get_pools_listing():
 
     Notes
     -----
-    Reproduces the functionality of:
-    [p.id, p.container.external_id, p.is_plate_pool, p.upstream_process.id]
-     for p in PoolComposition.get_pools()]
-    but with direct calls to the database
+    Reproduces the functionality of getting various information from a pool
+    object and its components (e.g., p.id, p.container.external_id,
+    p.upstream_process.id, etc) but with direct calls to the database
     """
+    pool_composition_desc = composition.PoolComposition.\
+        get_composition_type_description()
+    amplicon_composition_desc = composition.LibraryPrep16SComposition.\
+        get_composition_type_description()
+
     with sql_connection.TRN as TRN:
         sql = """SELECT pool_composition_id, external_id,
-                    (SELECT DISTINCT description != 'pool'
+                    (SELECT DISTINCT description != '{0}'
                      FROM labman.pool_composition_components
                      LEFT JOIN labman.composition ON (
                          input_composition_id = composition_iD)
                      LEFT JOIN labman.composition_type USING (
                          composition_type_id)
                      WHERE output_pool_composition_id = pool_composition_id)
-                     as is_plate_pool, upstream_process_id
+                     as is_plate_pool,
+                    (SELECT DISTINCT description = '{1}'
+                     FROM labman.pool_composition_components
+                     LEFT JOIN labman.composition ON (
+                         input_composition_id = composition_iD)
+                     LEFT JOIN labman.composition_type USING (
+                         composition_type_id)
+                     WHERE output_pool_composition_id = pool_composition_id)
+                     as is_amplicon_plate_pool, upstream_process_id
                  FROM labman.pool_composition
                  LEFT JOIN labman.composition USING (composition_id)
                  LEFT JOIN labman.tube USING (container_id)
                  LEFT JOIN labman.composition_type USING (composition_type_id)
-                 ORDER BY pool_composition_id"""
+                 ORDER BY pool_composition_id""".format(
+            pool_composition_desc, amplicon_composition_desc)
         TRN.add(sql)
 
         # if you are looking for a way to improve performance, you would
         # need to:
         # 1. Create a database table with all the process.Process.factory
         # factory_classes
-        # 2. retrieve the table names that corresponde to each object
+        # 2. retrieve the table names that correspond to each object
         # 3. reproduce what process.Process.factory does but in the database
-        return [[pid, eid, ipp, process.Process.factory(upi).id]
-                for pid, eid, ipp, upi in TRN.execute_fetchindex()]
+        return [[pid, eid, ipp, iap, process.Process.factory(upi).id]
+                for pid, eid, ipp, iap, upi in TRN.execute_fetchindex()
+                if ipp in is_plate_pool_limits and
+                iap in is_amplicon_plate_pool_limits]

--- a/labcontrol/gui/handlers/pool.py
+++ b/labcontrol/gui/handlers/pool.py
@@ -22,8 +22,24 @@ class PoolListingHandler(BaseHandler):
 
 class PoolListHandler(BaseHandler):
     @authenticated
-    def get(self):
-        res = {"data": get_pools_listing()}
+    def get(self, list_type):
+        if list_type == "amplicon_plate":
+            is_plate_pool_limits = [True]
+            is_amplicon_plate_pool_limits = [True]
+        elif list_type == "amplicon_sequencing":
+            is_plate_pool_limits = [False]
+            is_amplicon_plate_pool_limits = [False]
+        elif list_type == "metagenomics_plate":
+            is_plate_pool_limits = [True]
+            is_amplicon_plate_pool_limits = [False]
+        elif list_type == "all":
+            is_plate_pool_limits = [True, False]
+            is_amplicon_plate_pool_limits = [True, False]
+        else:
+            raise ValueError("Unknown plate list type: {0}".format(list_type))
+
+        res = {"data": get_pools_listing(is_plate_pool_limits,
+                                         is_amplicon_plate_pool_limits)}
         self.write(res)
 
 

--- a/labcontrol/gui/handlers/pool.py
+++ b/labcontrol/gui/handlers/pool.py
@@ -29,7 +29,7 @@ class PoolListHandler(BaseHandler):
         elif list_type == "amplicon_sequencing":
             is_plate_pool_limits = [False]
             is_amplicon_plate_pool_limits = [False]
-        elif list_type == "metagenomics_plate":
+        elif list_type == "shotgun_plate":
             is_plate_pool_limits = [True]
             is_amplicon_plate_pool_limits = [False]
         elif list_type == "all":

--- a/labcontrol/gui/handlers/process_handlers/__init__.py
+++ b/labcontrol/gui/handlers/process_handlers/__init__.py
@@ -57,7 +57,7 @@ PROCESS_ENDPOINTS = [
     (r"/process/poolpools$", PoolPoolProcessHandler),
     (r"/process/poollibraries$", LibraryPoolProcessHandler),
     (r"/process/poollibraries/([0-9]+)/pool_file$", DownloadPoolFileHandler),
-    (r"/process/sequencing$", SequencingProcessHandler),
+    (r"/process/sequencing/(.*)/", SequencingProcessHandler),
     (r"/process/library_prep_shotgun$", LibraryPrepShotgunProcessHandler),
     (r"/process/library_prep_shotgun/([0-9]+)/echo_pick_list$",
      DownloadLibraryPrepShotgunProcessHandler),

--- a/labcontrol/gui/handlers/process_handlers/sequencing_process.py
+++ b/labcontrol/gui/handlers/process_handlers/sequencing_process.py
@@ -35,7 +35,11 @@ class SequencingProcessHandler(BaseHandler):
                     allowed_pools_name=allowed_pools_name)
 
     @authenticated
-    def post(self):
+    # Note that the input argument, which is allowed_pools_type, is not
+    # actually used; however, it needs to be passed in since this handler
+    # requires that information for the get method, and get and post have to
+    # work on the same URL.
+    def post(self, _):
         pools = self.get_argument('pools')
         run_name = self.get_argument('run_name')
         experiment = self.get_argument('experiment')

--- a/labcontrol/gui/handlers/process_handlers/sequencing_process.py
+++ b/labcontrol/gui/handlers/process_handlers/sequencing_process.py
@@ -22,14 +22,17 @@ from labcontrol.db.process import SequencingProcess
 
 class SequencingProcessHandler(BaseHandler):
     @authenticated
-    def get(self):
+    def get(self, allowed_pools_type):
         sequencers = []
+        allowed_pools_name = allowed_pools_type.split("_")[0].title()
         for model, lanes in SequencingProcess.sequencer_lanes.items():
             for sequencer in Equipment.list_equipment(model):
                 sequencer['lanes'] = lanes
                 sequencers.append(sequencer)
         self.render('sequencing.html', users=User.list_users(),
-                    sequencers=sequencers)
+                    sequencers=sequencers,
+                    allowed_pools_type=allowed_pools_type,
+                    allowed_pools_name=allowed_pools_name)
 
     @authenticated
     def post(self):

--- a/labcontrol/gui/handlers/process_handlers/test/test_sequencing_process.py
+++ b/labcontrol/gui/handlers/process_handlers/test/test_sequencing_process.py
@@ -16,8 +16,8 @@ from labcontrol.gui.testing import TestHandlerBase
 
 
 class TestSequencingProcessHandler(TestHandlerBase):
-    def test_get_sequencing_process_handler(self):
-        response = self.get('/process/sequencing')
+    def test_get_sequencing_process_handler_pool_type(self):
+        response = self.get('/process/sequencing/somepooltype/')
         self.assertEqual(response.code, 200)
         self.assertNotEqual(response.body, '')
 
@@ -28,7 +28,7 @@ class TestSequencingProcessHandler(TestHandlerBase):
                 'principal_investigator': 'admin@foo.bar',
                 'additional_contacts': json_encode(
                     ['demo@microbio.me', 'shared@foo.bar'])}
-        response = self.post('/process/sequencing', data)
+        response = self.post('/process/sequencing/couldbeanything/', data)
         self.assertEqual(response.code, 200)
         self.assertCountEqual(json_decode(response.body), ['process'])
 

--- a/labcontrol/gui/templates/pool_list.html
+++ b/labcontrol/gui/templates/pool_list.html
@@ -9,13 +9,17 @@
        'order': [[1, "desc"]],
        'language': {'zeroRecords': 'Loading records, please wait ...'}});
 
-    $.get('/pool_list', function(data) {
+    $.get('/pool_list/all/', function(data) {
       var datatable = $('#poolListTable').DataTable();
       var newData = [];
       for (var row of data.data) {
-        // Add the checkbox
-        var chBox = '<input type="checkbox" class="table-checkbox" data-lb-pool-id="' + row[0] + '"></input>';
+        // Disable the checkbox to select amplicon plate pools to add to an
+        // amplicon sequencing pool if this is NOT an amplicon plate pool
+        var checkboxDisabled = row[3] === false ? " disabled" : "";
+        var chBox = '<input type="checkbox" class="table-checkbox"' + checkboxDisabled + ' data-lb-pool-id="' + row[0] + '"></input>';
         var poolFileButton = '';
+        // Allow download pool file only if this is a plate pool (not an
+        // pool of pools)
         if (row[2] === true){
             poolFileButton = '<a href="/process/poollibraries/' + row[3] + '/pool_file" class="btn btn-success">' +
             '<span class="glyphicon glyphicon-download"></span> ' +
@@ -32,7 +36,7 @@
           $(this).parent('td').parent('tr').addClass('dt-selected');
           dtSelectedCounter += 1;
           if (dtSelectedCounter === 1) {
-            $('<button>').addClass('btn btn-info').append('Prepare sequencing pool').appendTo('#btn-div').on('click', function () {
+            $('<button>').addClass('btn btn-info').append('Prepare amplicon sequencing pool').appendTo('#btn-div').on('click', function () {
               var poolIds = [];
               for (var inTag of $('.dt-selected').find('input')) {
                 poolIds.push($(inTag).attr('data-lb-pool-id'));

--- a/labcontrol/gui/templates/pool_list.html
+++ b/labcontrol/gui/templates/pool_list.html
@@ -13,10 +13,13 @@
       var datatable = $('#poolListTable').DataTable();
       var newData = [];
       for (var row of data.data) {
-        // Disable the checkbox to select amplicon plate pools to add to an
-        // amplicon sequencing pool if this is NOT an amplicon plate pool
-        var checkboxDisabled = row[3] === false ? " disabled" : "";
-        var chBox = '<input type="checkbox" class="table-checkbox"' + checkboxDisabled + ' data-lb-pool-id="' + row[0] + '"></input>';
+        // Include the checkbox to select pools to add to an amplicon
+        // sequencing pool ONLY if this pool is an amplicon plate pool;
+        // otherwise, put "N/A" in that cell in the table
+        var chBox = "N/A&nbsp;";
+        if (row[3] === true) {
+            chBox = '<input type="checkbox" class="table-checkbox" data-lb-pool-id="' + row[0] + '"></input>';
+        }
         var poolFileButton = '';
         // Allow download pool file only if this is a plate pool (not an
         // pool of pools)
@@ -75,6 +78,8 @@
     </tr>
   </thead>
 </table>
+
+<div><em>Pools that cannot be used as input to an amplicon sequencing pool are marked with 'N/A'.</em></div>
 
 <div id='btn-div'></div>
 {% end %}

--- a/labcontrol/gui/templates/pool_pooling.html
+++ b/labcontrol/gui/templates/pool_pooling.html
@@ -180,7 +180,7 @@
   $(document).ready(function(){
     // Set the pool search table
     var table = $('#searchPoolTable').DataTable(
-      {'ajax': {'url': '/pool_list'},
+      {'ajax': {'url': '/pool_list/amplicon_plate/'},
        'columnDefs': [{'targets': -1,
                        'data': null,
                        'render': function(data, type, row, meta){
@@ -214,7 +214,7 @@
 {% end %}
 
 {% block content %}
-<h3>Prepare sequencing pool</h3>
+<h3>Prepare amplicon sequencing pool</h3>
 
 <!-- Pool name -->
 <div id='poolNameDiv' class='form-group has-error has-feedback'>

--- a/labcontrol/gui/templates/sequencing.html
+++ b/labcontrol/gui/templates/sequencing.html
@@ -24,7 +24,7 @@
                       'rev_cycles': $('#rev-input').val(),
                       'principal_investigator': $('#pi-select').val(),
                       'additional_contacts': JSON.stringify(contacts)}
-    $.post('/process/sequencing', postParams, function(data) {
+    $.post('/process/sequencing/{% raw allowed_pools_type %}/', postParams, function(data) {
       bootstrapAlert('Information saved', 'success');
       $("html, body").animate({scrollTop: 0}, 500);
       disableAll();
@@ -101,10 +101,8 @@
     $('.labman-input').on('change', submitChecks);
     $('#add-pool-btn').prop('disabled', true);
 
-    var allowed_pools_type = '{% raw allowed_pools_type %}';
-
     var table = $('#searchPoolTable').DataTable(
-      {'ajax': {'url': '/pool_list/'+ allowed_pools_type + '/'},
+      {'ajax': {'url': '/pool_list/{% raw allowed_pools_type %}/'},
        'columnDefs': [{'targets': -1,
                        'data': null,
                        'render': function(data, type, row, meta) {

--- a/labcontrol/gui/templates/sequencing.html
+++ b/labcontrol/gui/templates/sequencing.html
@@ -101,8 +101,10 @@
     $('.labman-input').on('change', submitChecks);
     $('#add-pool-btn').prop('disabled', true);
 
+    var allowed_pools_type = '{% raw allowed_pools_type %}';
+
     var table = $('#searchPoolTable').DataTable(
-      {'ajax': {'url': '/pool_list'},
+      {'ajax': {'url': '/pool_list/'+ allowed_pools_type + '/'},
        'columnDefs': [{'targets': -1,
                        'data': null,
                        'render': function(data, type, row, meta) {
@@ -141,7 +143,7 @@
 {% end %}
 
 {% block content %}
-<label><h3>Sequencing run</h3></label>
+<label><h3>{% raw allowed_pools_name %} Sequencing run</h3></label>
 <span id="run-name-title"></span>
 
 <!-- Run name -->

--- a/labcontrol/gui/templates/sitebase.html
+++ b/labcontrol/gui/templates/sitebase.html
@@ -86,7 +86,7 @@
                 <ul class="dropdown-menu">
                   <li><a href="/sequence_runs">List</a></li>
                   <li><a href="/process/sequencing/amplicon_sequencing/">Prepare amplicon sequencing run</a></li>
-                  <li><a href="/process/sequencing/metagenomics_plate/">Prepare metagenomics sequencing run</a></li>
+                  <li><a href="/process/sequencing/shotgun_plate/">Prepare shotgun sequencing run</a></li>
                 </ul>
               </li>
               <li class="dropdown">

--- a/labcontrol/gui/templates/sitebase.html
+++ b/labcontrol/gui/templates/sitebase.html
@@ -85,7 +85,8 @@
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Sequencing runs <span class="caret"></span></a>
                 <ul class="dropdown-menu">
                   <li><a href="/sequence_runs">List</a></li>
-                  <li><a href="/process/sequencing">Prepare sequencing run</a></li>
+                  <li><a href="/process/sequencing/amplicon_sequencing/">Prepare amplicon sequencing run</a></li>
+                  <li><a href="/process/sequencing/metagenomics_plate/">Prepare metagenomics sequencing run</a></li>
                 </ul>
               </li>
               <li class="dropdown">

--- a/labcontrol/gui/test/test_pool.py
+++ b/labcontrol/gui/test/test_pool.py
@@ -13,20 +13,65 @@ from labcontrol.gui.testing import TestHandlerBase
 
 
 class TestPoolHandlers(TestHandlerBase):
-    def test_get_plate_list_handler(self):
-        response = self.get('/pool_list')
+    def test_get_pool_list_handler_all(self):
+        response = self.get('/pool_list/all/')
         self.assertEqual(response.code, 200)
         obs = json_decode(response.body)
         self.assertCountEqual(obs.keys(), ['data'])
         obs_data = obs['data']
         self.assertEqual(len(obs_data), 6)
-        self.assertEqual(obs_data[0], [1, 'Test Pool from Plate 1', True, 1])
-        self.assertEqual(obs_data[1], [2, 'Test sequencing pool 1', False, 2])
+        self.assertEqual(obs_data[0], [1, 'Test Pool from Plate 1',
+                                       True, True, 1])
+        self.assertEqual(obs_data[1], [2, 'Test sequencing pool 1',
+                                       False, False, 2])
         self.assertEqual(obs_data[2], [3, 'Test pool from Shotgun plates 1-4',
-                                       True, 3])
-        self.assertEqual(obs_data[3], [4, 'Test Pool from Plate 2', True, 4])
-        self.assertEqual(obs_data[4], [5, 'Test Pool from Plate 3', True, 5])
-        self.assertEqual(obs_data[5], [6, 'Test Pool from Plate 4', True, 6])
+                                       True, False, 3])
+        self.assertEqual(obs_data[3], [4, 'Test Pool from Plate 2',
+                                       True, True, 4])
+        self.assertEqual(obs_data[4], [5, 'Test Pool from Plate 3',
+                                       True, True, 5])
+        self.assertEqual(obs_data[5], [6, 'Test Pool from Plate 4',
+                                       True, True, 6])
+
+    def test_get_pool_list_handler_amplicon_plate(self):
+        response = self.get('/pool_list/amplicon_plate/')
+        self.assertEqual(response.code, 200)
+        obs = json_decode(response.body)
+        self.assertCountEqual(obs.keys(), ['data'])
+        obs_data = obs['data']
+        self.assertEqual(len(obs_data), 4)
+        self.assertEqual(obs_data[0], [1, 'Test Pool from Plate 1',
+                                       True, True, 1])
+        self.assertEqual(obs_data[1], [4, 'Test Pool from Plate 2',
+                                       True, True, 4])
+        self.assertEqual(obs_data[2], [5, 'Test Pool from Plate 3',
+                                       True, True, 5])
+        self.assertEqual(obs_data[3], [6, 'Test Pool from Plate 4',
+                                       True, True, 6])
+
+    def test_get_pool_list_handler_amplicon_sequencing(self):
+        response = self.get('/pool_list/amplicon_sequencing/')
+        self.assertEqual(response.code, 200)
+        obs = json_decode(response.body)
+        self.assertCountEqual(obs.keys(), ['data'])
+        obs_data = obs['data']
+        self.assertEqual(len(obs_data), 1)
+        self.assertEqual(obs_data[0], [2, 'Test sequencing pool 1',
+                                       False, False, 2])
+
+    def test_get_pool_list_handler_metagenomics_plate(self):
+        response = self.get('/pool_list/metagenomics_plate/')
+        self.assertEqual(response.code, 200)
+        obs = json_decode(response.body)
+        self.assertCountEqual(obs.keys(), ['data'])
+        obs_data = obs['data']
+        self.assertEqual(len(obs_data), 1)
+        self.assertEqual(obs_data[0], [3, 'Test pool from Shotgun plates 1-4',
+                                       True, False, 3])
+
+    def test_get_pool_list_handler_unknown(self):
+        response = self.get('/pool_list/minipcr/')
+        self.assertEqual(response.code, 500)
 
 
 if __name__ == '__main__':

--- a/labcontrol/gui/test/test_pool.py
+++ b/labcontrol/gui/test/test_pool.py
@@ -59,8 +59,8 @@ class TestPoolHandlers(TestHandlerBase):
         self.assertEqual(obs_data[0], [2, 'Test sequencing pool 1',
                                        False, False, 2])
 
-    def test_get_pool_list_handler_metagenomics_plate(self):
-        response = self.get('/pool_list/metagenomics_plate/')
+    def test_get_pool_list_handler_shotgun_plate(self):
+        response = self.get('/pool_list/shotgun_plate/')
         self.assertEqual(response.code, 200)
         obs = json_decode(response.body)
         self.assertCountEqual(obs.keys(), ['data'])

--- a/labcontrol/gui/webserver.py
+++ b/labcontrol/gui/webserver.py
@@ -55,7 +55,7 @@ class Application(tornado.web.Application):
                     (r"/plate$", PlateMapHandler),
                     (r"/platename", PlateNameHandler),
                     # Pool handlers
-                    (r"/pool_list$", PoolListHandler),
+                    (r"/pool_list/(.*)/", PoolListHandler),
                     (r"/pool/(.*)/", PoolHandler),
                     (r"/pools$", PoolListingHandler),
                     # Sequence handlers


### PR DESCRIPTION
While investigating the causes of #420 "Prepare Amplicon Sequencing Pool allows user to add metagenomics (not amplicon) plate pools, which leads to error downstream in sequencing run sample sheet preparation", I also found issues #497 "Pool list page checkboxes allows user to add metagenomics (not amplicon) plate pools, which leads to error downstream in sequencing run sample sheet preparation" (very similar to 420) and #498 "Prepare Sequencing Run allows users to mix amplicon and metagenomics pools, which leads to error downstream in sequencing run sample sheet preparation".  Basically all of these are related to the fact that although pools can be made up of any arbitrary contents (including any combination of amplicon library preps, shotgun library preps, and/or other pools), **it isn't currently sensical to *sequence* such a pool** as we don't know what the downstream outputs (sample sheets and/or prep sheets) for arbitrary pools (made up of mixtures of types of inputs) should look like.

For now, I solved all three of these issues by limiting which kinds of inputs are available to the user when creating an amplicon sequencing pool (can only input amplicon plate pools), a shotgun sequencing run (can only input shotgun plate pools), or an amplicon sequencing run (can only input amplicon sequencing pools).  In the future, we may decide that (a) there are realistic use-cases for mixing the types of inputs that go into a pool AND (b) we understand what the downstream outputs for sequencing runs of arbitrary pools should look like.  If and when that day comes, we will want to take out the limitations I have added here.

Note that these limitations *prevent* the case described in issue #444 "Modify generate_prep_information to correctly create prep sheets for sequencing runs based on library plate pools" from occurring, thus making it a low priority to fix.

Also note that there are some known code smells here ... for example, an examination of what kinds of library prep components go into a pool is now happening in `util.py`'s `get_pool_listing` as well as in `process.py`'s `SequencingProcess.create()` (the latter of which I am starting to think is the wrong place for it and is related to the bug for issue #498), and the definition of "amplicon_sequencing" pools as given in `PoolListHandler.get()` would also catch additional kinds of pools if we add additional protocols.  Fixing these smells will take a bit of thoughtful refactoring of how and where we identify different assay types; if this PR gets approved, I'll add an issue for that.