### PR TITLE
Fixes bug reported by MacKenzie of empty add plate modal

### DIFF
--- a/labcontrol/gui/static/js/addPlateModal.js
+++ b/labcontrol/gui/static/js/addPlateModal.js
@@ -192,7 +192,8 @@ function setUpAddPlateModal(plateTypeList, getOnlyQuantified,
         // contains just one entry--also with the key "data"
         let plateListInfo = (data["data"]);
         let tableSelectorStr = "#" + plateTableId;
-        let table = populatePlateTable(tableSelectorStr, plateListInfo);
+        let table = populatePlateTable(plateListInfo, tableSelectorStr,
+            specificAddPlateBtnBaseId);
 
         let tbodySelector = $(tableSelectorStr + ' tbody');
         // Remove any existing event handler already attached to plate add btns


### PR DESCRIPTION
plate modal was not being populated after addPlateModal.js refactor :(  I had reversed the order of two parameters and failed to pass one that I changed from default to explicit.