### PR TITLE
WIP: Rename 'kappa' to 'Kapa'

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -259,7 +259,7 @@ This brings you to the “Shotgun library prep” page. Here, you will choose th
 
 This will bring up a text box asking for information on your shotgun libraries. Here you will be asked to select index primers by separately selecting your “i5 plate” and your “i7 plate”. As with equipment like robots, primer plates are expected to be added infrequently, and must already exist in the database.
 
-You will then be asked to name your plate, input your “kappa hyper plus kit”, input your “Stub lot” and input your “Volume (mL)”. Though all of the options are free text, if the “kappa hyper plus kit” and “Stub lot” do not exist, you will be prompted to add them to the system.
+You will then be asked to name your plate, input your “kapa hyper plus kit”, input your “Stub lot” and input your “Volume (mL)”. Though all of the options are free text, if the “kapa hyper plus kit” and “Stub lot” do not exist, you will be prompted to add them to the system.
 
 When you are finished with preparing your shotgun libraries, select “Prepare libraries” and you will be returned to the home screen.
 

--- a/labcontrol/db/process.py
+++ b/labcontrol/db/process.py
@@ -1404,7 +1404,7 @@ class LibraryPrepShotgunProcess(Process):
 
     Attributes
     ----------
-    kappa_hyper_plus_kit
+    kapa_hyper_plus_kit
     stub_lot
     normalization_process
 
@@ -1417,7 +1417,7 @@ class LibraryPrepShotgunProcess(Process):
     _process_type = 'shotgun library prep'
 
     @classmethod
-    def create(cls, user, plate, plate_name, kappa_hyper_plus_kit, stub_lot,
+    def create(cls, user, plate, plate_name, kapa_hyper_plus_kit, stub_lot,
                volume, i5_plate, i7_plate):
         """Creats a new LibraryPrepShotgunProcess
 
@@ -1429,8 +1429,8 @@ class LibraryPrepShotgunProcess(Process):
             The normalized gDNA plate of origin
         plate_name: str
             The library
-        kappa_hyper_plus_kit: labcontrol.db.composition.ReagentComposition
-            The Kappa Hyper Plus kit used
+        kapa_hyper_plus_kit: labcontrol.db.composition.ReagentComposition
+            The Kapa Hyper Plus kit used
         stub_lot: labcontrol.db.composition.ReagentComposition
             The stub lot used
         volume : float
@@ -1452,7 +1452,7 @@ class LibraryPrepShotgunProcess(Process):
 
             # Add the row to the library_prep_shotgun_process
             sql = """INSERT INTO labman.library_prep_shotgun_process
-                        (process_id, kappa_hyper_plus_kit_id, stub_lot_id,
+                        (process_id, kapa_hyper_plus_kit_id, stub_lot_id,
                          normalization_process_id)
                      VALUES (%s, %s, %s, (
                         SELECT DISTINCT normalization_process_id
@@ -1463,7 +1463,7 @@ class LibraryPrepShotgunProcess(Process):
                                 JOIN labman.well USING (container_id)
                                 WHERE plate_id = %s))
                      RETURNING library_prep_shotgun_process_id"""
-            TRN.add(sql, [process_id, kappa_hyper_plus_kit.id, stub_lot.id,
+            TRN.add(sql, [process_id, kapa_hyper_plus_kit.id, stub_lot.id,
                           plate.id])
             instance = cls(TRN.execute_fetchlast())
 
@@ -1555,15 +1555,15 @@ class LibraryPrepShotgunProcess(Process):
         return instance
 
     @property
-    def kappa_hyper_plus_kit(self):
-        """The Kappa Hyper plus kit used
+    def kapa_hyper_plus_kit(self):
+        """The Kapa Hyper Plus kit used
 
         Returns
         -------
         ReagentComposition
         """
         return composition_module.ReagentComposition(
-            self._get_attr('kappa_hyper_plus_kit_id'))
+            self._get_attr('kapa_hyper_plus_kit_id'))
 
     @property
     def stub_lot(self):
@@ -3913,7 +3913,7 @@ class SequencingProcess(Process):
                     gdnaextractpr.epmotion_robot_id AS gepmotion_robot_id,
                     gdnaextractpr.epmotion_tool_id,
                     gdnaextractpr.kingfisher_robot_id,
-                    libpreppr.kappa_hyper_plus_kit_id,
+                    libpreppr.kapa_hyper_plus_kit_id,
                     libpreppr.stub_lot_id,
                     primersetcp.barcode_seq AS barcode_i5,
                     primersetcp2.barcode_seq AS barcode_i7,
@@ -4032,9 +4032,8 @@ class SequencingProcess(Process):
                 # query.
                 d['instrument_model'] = inst_mdl
 
-                # note that the correct term is 'Kapa', not 'kappa'.
-                id = d['kappa_hyper_plus_kit_id']
-                d['kappa_hyper_plus_kit_lot'] = reagent[id]['external_lot_id']
+                id = d['kapa_hyper_plus_kit_id']
+                d['kapa_hyper_plus_kit_lot'] = reagent[id]['external_lot_id']
 
                 id = d['stub_lot_id']
                 d['stub_lot_id'] = reagent[id]['external_lot_id']
@@ -4182,9 +4181,7 @@ class SequencingProcess(Process):
                   "experiment_design_description":
                       "EXPERIMENT_DESIGN_DESCRIPTION",
                   "instrument_model": "INSTRUMENT_MODEL",
-                  # Please refer to 'Kapa' vs 'kappa' at
-                  # https://github.com/jdereus/labman/issues/503
-                  "kappa_hyper_plus_kit_lot": "KapaHyperPlusKit_lot",
+                  "kapa_hyper_plus_kit_lot": "KapaHyperPlusKit_lot",
                   "stub_lot_id": "Stub_lot",
                   "platform": "PLATFORM",
                   "sequencing_method": "sequencing_meth",

--- a/labcontrol/db/support_files/db_patch.sql
+++ b/labcontrol/db/support_files/db_patch.sql
@@ -477,7 +477,7 @@ CREATE INDEX idx_16s_library_prep_composition_1 ON labman.library_prep_16s_compo
 CREATE TABLE labman.library_prep_shotgun_process (
 	library_prep_shotgun_process_id bigserial  NOT NULL,
 	process_id           integer  NOT NULL,
-	kappa_hyper_plus_kit_id integer  NOT NULL,
+	kapa_hyper_plus_kit_id integer  NOT NULL,
 	stub_lot_id          integer  NOT NULL,
 	normalization_process_id integer  NOT NULL,
 	CONSTRAINT pk_shotgun_library_prep_process PRIMARY KEY ( library_prep_shotgun_process_id )
@@ -485,7 +485,7 @@ CREATE TABLE labman.library_prep_shotgun_process (
 
 CREATE INDEX idx_shotgun_library_prep_process_process ON labman.library_prep_shotgun_process ( process_id );
 
-CREATE INDEX idx_shotgun_library_prep_process_kappa ON labman.library_prep_shotgun_process ( kappa_hyper_plus_kit_id );
+CREATE INDEX idx_shotgun_library_prep_process_kapa ON labman.library_prep_shotgun_process ( kapa_hyper_plus_kit_id );
 
 CREATE INDEX idx_shotgun_library_prep_process_stub ON labman.library_prep_shotgun_process ( stub_lot_id );
 
@@ -589,7 +589,7 @@ ALTER TABLE labman.library_prep_shotgun_composition ADD CONSTRAINT fk_shotgun_li
 
 ALTER TABLE labman.library_prep_shotgun_process ADD CONSTRAINT fk_shotgun_library_prep_process FOREIGN KEY ( process_id ) REFERENCES labman.process( process_id );
 
-ALTER TABLE labman.library_prep_shotgun_process ADD CONSTRAINT fk_shotgun_library_prep_process_kappa FOREIGN KEY ( kappa_hyper_plus_kit_id ) REFERENCES labman.reagent_composition( reagent_composition_id );
+ALTER TABLE labman.library_prep_shotgun_process ADD CONSTRAINT fk_shotgun_library_prep_process_kapa FOREIGN KEY ( kapa_hyper_plus_kit_id ) REFERENCES labman.reagent_composition( reagent_composition_id );
 
 ALTER TABLE labman.library_prep_shotgun_process ADD CONSTRAINT fk_shotgun_library_prep_process_stub FOREIGN KEY ( stub_lot_id ) REFERENCES labman.reagent_composition( reagent_composition_id );
 

--- a/labcontrol/db/support_files/db_patch_manual.sql
+++ b/labcontrol/db/support_files/db_patch_manual.sql
@@ -77,7 +77,7 @@ INSERT INTO labman.composition_type (description) VALUES
 
 -- Populate reagent composition type
 INSERT INTO labman.reagent_composition_type (description) VALUES
-    ('extraction kit'), ('master mix'), ('water'), ('kappa hyper plus kit'), ('shotgun stubs');
+    ('extraction kit'), ('master mix'), ('water'), ('kapa hyper plus kit'), ('shotgun stubs');
 
 -- Populate sample composition type
 INSERT INTO labman.sample_composition_type (external_id, description, include_in_libraries) VALUES

--- a/labcontrol/db/support_files/labcontrol.dbs
+++ b/labcontrol/db/support_files/labcontrol.dbs
@@ -334,7 +334,7 @@
 		<table name="library_prep_shotgun_process" >
 			<column name="library_prep_shotgun_process_id" type="bigserial" jt="-5" mandatory="y" />
 			<column name="process_id" type="integer" jt="4" mandatory="y" />
-			<column name="kappa_hyper_plus_kit_id" type="integer" jt="4" mandatory="y" />
+			<column name="kapa_hyper_plus_kit_id" type="integer" jt="4" mandatory="y" />
 			<column name="stub_lot_id" type="integer" jt="4" mandatory="y" >
 				<comment><![CDATA[should there be more than one of these?]]></comment>
 			</column>
@@ -345,8 +345,8 @@
 			<index name="idx_shotgun_library_prep_process_process" unique="NORMAL" >
 				<column name="process_id" />
 			</index>
-			<index name="idx_shotgun_library_prep_process_kappa" unique="NORMAL" >
-				<column name="kappa_hyper_plus_kit_id" />
+			<index name="idx_shotgun_library_prep_process_kapa" unique="NORMAL" >
+				<column name="kapa_hyper_plus_kit_id" />
 			</index>
 			<index name="idx_shotgun_library_prep_process_stub" unique="NORMAL" >
 				<column name="stub_lot_id" />
@@ -357,8 +357,8 @@
 			<fk name="fk_shotgun_library_prep_process" to_schema="labman" to_table="process" >
 				<fk_column name="process_id" pk="process_id" />
 			</fk>
-			<fk name="fk_shotgun_library_prep_process_kappa" to_schema="labman" to_table="reagent_composition" >
-				<fk_column name="kappa_hyper_plus_kit_id" pk="reagent_composition_id" />
+			<fk name="fk_shotgun_library_prep_process_kapa" to_schema="labman" to_table="reagent_composition" >
+				<fk_column name="kapa_hyper_plus_kit_id" pk="reagent_composition_id" />
 			</fk>
 			<fk name="fk_shotgun_library_prep_process_stub" to_schema="labman" to_table="reagent_composition" >
 				<fk_column name="stub_lot_id" pk="reagent_composition_id" />

--- a/labcontrol/db/support_files/labcontrol.html
+++ b/labcontrol/db/support_files/labcontrol.html
@@ -721,14 +721,14 @@ library_prep_shotgun_process ref process ( process_id )</title>
 <path transform='translate(8,0)' marker-start='url(#foot1p)'     d='M 1008 1328 L 968,1328 Q 960,1328 960,1320 L 960,1088' ></path>
 <text x='846' y='1323' transform='rotate(0 846,1323)' title='Fk fk_shotgun_library_prep_process
 library_prep_shotgun_process ref process ( process_id )' class='relName' style='fill:#748EA7'>fk_shotgun_library_prep_process</text>
-<!-- == Fk 'library_prep_shotgun_process_fk_shotgun_library_prep_process_kappa' == -->
-<path id='library_prep_shotgun_process_fk_shotgun_library_prep_process_kappa'  onmouseover="hghl(['library_prep_shotgun_process_fk_shotgun_library_prep_process_kappa','labman.library_prep_shotgun_process.kappa_hyper_plus_kit_id','labman.reagent_composition.reagent_composition_id'])" onmouseout="uhghl(['library_prep_shotgun_process_fk_shotgun_library_prep_process_kappa','labman.library_prep_shotgun_process.kappa_hyper_plus_kit_id','labman.reagent_composition.reagent_composition_id'])" transform='translate(8,0)' class='scene' d='M 1232 1344 L 1240,1344 Q 1248,1344 1248,1336 L 1248,872 Q 1248,864 1240,864 L 360,864 Q 352,864 352,856 L 352,848' >
-	<title>Fk fk_shotgun_library_prep_process_kappa
-library_prep_shotgun_process ref reagent_composition ( kappa_hyper_plus_kit_id -&gt; reagent_composition_id )</title>
+<!-- == Fk 'library_prep_shotgun_process_fk_shotgun_library_prep_process_kapa' == -->
+<path id='library_prep_shotgun_process_fk_shotgun_library_prep_process_kapa'  onmouseover="hghl(['library_prep_shotgun_process_fk_shotgun_library_prep_process_kapa','labman.library_prep_shotgun_process.kapa_hyper_plus_kit_id','labman.reagent_composition.reagent_composition_id'])" onmouseout="uhghl(['library_prep_shotgun_process_fk_shotgun_library_prep_process_kapa','labman.library_prep_shotgun_process.kapa_hyper_plus_kit_id','labman.reagent_composition.reagent_composition_id'])" transform='translate(8,0)' class='scene' d='M 1232 1344 L 1240,1344 Q 1248,1344 1248,1336 L 1248,872 Q 1248,864 1240,864 L 360,864 Q 352,864 352,856 L 352,848' >
+	<title>Fk fk_shotgun_library_prep_process_kapa
+library_prep_shotgun_process ref reagent_composition ( kapa_hyper_plus_kit_id -&gt; reagent_composition_id )</title>
 </path>
 <path transform='translate(8,0)' marker-start='url(#foot1p)'     d='M 1232 1344 L 1240,1344 Q 1248,1344 1248,1336 L 1248,872 Q 1248,864 1240,864 L 360,864 Q 352,864 352,856 L 352,848' ></path>
-<text x='1241' y='1339' transform='rotate(0 1241,1339)' title='Fk fk_shotgun_library_prep_process_kappa
-library_prep_shotgun_process ref reagent_composition ( kappa_hyper_plus_kit_id -&gt; reagent_composition_id )' class='relName' style='fill:#748EA7'>fk_shotgun_library_prep_process_kappa</text>
+<text x='1241' y='1339' transform='rotate(0 1241,1339)' title='Fk fk_shotgun_library_prep_process_kapa
+library_prep_shotgun_process ref reagent_composition ( kapa_hyper_plus_kit_id -&gt; reagent_composition_id )' class='relName' style='fill:#748EA7'>fk_shotgun_library_prep_process_kapa</text>
 <!-- == Fk 'library_prep_shotgun_process_fk_shotgun_library_prep_process_stub' == -->
 <path id='library_prep_shotgun_process_fk_shotgun_library_prep_process_stub'  onmouseover="hghl(['library_prep_shotgun_process_fk_shotgun_library_prep_process_stub','labman.library_prep_shotgun_process.stub_lot_id','labman.reagent_composition.reagent_composition_id'])" onmouseout="uhghl(['library_prep_shotgun_process_fk_shotgun_library_prep_process_stub','labman.library_prep_shotgun_process.stub_lot_id','labman.reagent_composition.reagent_composition_id'])" transform='translate(8,0)' class='scene' d='M 1232 1360 L 1240,1360 Q 1248,1360 1248,1352 L 1248,1328' >
 	<title>Fk fk_shotgun_library_prep_process_stub
@@ -1302,12 +1302,12 @@ real</title></a>
 <rect class='entity' x='128' y='360' width='192' height='112' rx='8' ry='8' style='fill:none;stroke:#C1D8EE'/>
 <a xlink:href='#reagent_composition'><text x='166' y='380'>reagent_composition</text><title>Table labman.reagent_composition</title></a>
   <use id='nn' x='130' y='397' xlink:href='#nn'/><a xlink:href='#reagent_composition.reagent_composition_id'><use id='pk' x='130' y='396' xlink:href='#pk'/><title>Pk pk_reagent ( reagent_composition_id ) </title></a>
-<a xlink:href='#reagent_composition.reagent_composition_id'><text id='labman.reagent_composition.reagent_composition_id' x='147' y='407' onmouseover="hghl(['gdna_extraction_process_fk_gdna_extraction_process_kit','labman.gdna_extraction_process.extraction_kit_id','library_prep_16s_process_fk_library_prep_16s_process_mm','labman.library_prep_16s_process.master_mix_id','library_prep_16s_process_fk_library_prep_16s_process_water','labman.library_prep_16s_process.water_lot_id','library_prep_shotgun_process_fk_shotgun_library_prep_process_kappa','labman.library_prep_shotgun_process.kappa_hyper_plus_kit_id','library_prep_shotgun_process_fk_shotgun_library_prep_process_stub','labman.library_prep_shotgun_process.stub_lot_id','normalization_process_fk_normalization_process_water','labman.normalization_process.water_lot_id'])" onmouseout="uhghl(['gdna_extraction_process_fk_gdna_extraction_process_kit','labman.gdna_extraction_process.extraction_kit_id','library_prep_16s_process_fk_library_prep_16s_process_mm','labman.library_prep_16s_process.master_mix_id','library_prep_16s_process_fk_library_prep_16s_process_water','labman.library_prep_16s_process.water_lot_id','library_prep_shotgun_process_fk_shotgun_library_prep_process_kappa','labman.library_prep_shotgun_process.kappa_hyper_plus_kit_id','library_prep_shotgun_process_fk_shotgun_library_prep_process_stub','labman.library_prep_shotgun_process.stub_lot_id','normalization_process_fk_normalization_process_water','labman.normalization_process.water_lot_id'])">reagent_composition_id</text><title>reagent_composition_id
+<a xlink:href='#reagent_composition.reagent_composition_id'><text id='labman.reagent_composition.reagent_composition_id' x='147' y='407' onmouseover="hghl(['gdna_extraction_process_fk_gdna_extraction_process_kit','labman.gdna_extraction_process.extraction_kit_id','library_prep_16s_process_fk_library_prep_16s_process_mm','labman.library_prep_16s_process.master_mix_id','library_prep_16s_process_fk_library_prep_16s_process_water','labman.library_prep_16s_process.water_lot_id','library_prep_shotgun_process_fk_shotgun_library_prep_process_kapa','labman.library_prep_shotgun_process.kapa_hyper_plus_kit_id','library_prep_shotgun_process_fk_shotgun_library_prep_process_stub','labman.library_prep_shotgun_process.stub_lot_id','normalization_process_fk_normalization_process_water','labman.normalization_process.water_lot_id'])" onmouseout="uhghl(['gdna_extraction_process_fk_gdna_extraction_process_kit','labman.gdna_extraction_process.extraction_kit_id','library_prep_16s_process_fk_library_prep_16s_process_mm','labman.library_prep_16s_process.master_mix_id','library_prep_16s_process_fk_library_prep_16s_process_water','labman.library_prep_16s_process.water_lot_id','library_prep_shotgun_process_fk_shotgun_library_prep_process_kapa','labman.library_prep_shotgun_process.kapa_hyper_plus_kit_id','library_prep_shotgun_process_fk_shotgun_library_prep_process_stub','labman.library_prep_shotgun_process.stub_lot_id','normalization_process_fk_normalization_process_water','labman.normalization_process.water_lot_id'])">reagent_composition_id</text><title>reagent_composition_id
 * bigserial</title></a>
 <a xlink:href='#reagent_composition.reagent_composition_id'><use id='ref' x='308' y='396' xlink:href='#ref'/><title>Referred by gdna_extraction_process ( extraction_kit_id -&gt; reagent_composition_id ) 
 Referred by library_prep_16s_process ( master_mix_id -&gt; reagent_composition_id ) 
 Referred by library_prep_16s_process ( water_lot_id -&gt; reagent_composition_id ) 
-Referred by library_prep_shotgun_process ( kappa_hyper_plus_kit_id -&gt; reagent_composition_id ) 
+Referred by library_prep_shotgun_process ( kapa_hyper_plus_kit_id -&gt; reagent_composition_id ) 
 Referred by library_prep_shotgun_process ( stub_lot_id -&gt; reagent_composition_id ) 
 Referred by normalization_process ( water_lot_id -&gt; reagent_composition_id ) </title></a>
   <use id='nn' x='130' y='413' xlink:href='#nn'/><a xlink:href='#reagent_composition.composition_id'><use id='idx' x='130' y='412' xlink:href='#idx'/><title>idx_reagent_composition ( composition_id ) </title></a>
@@ -1543,10 +1543,10 @@ varchar</title></a>
 <a xlink:href='#library_prep_shotgun_process.process_id'><text id='labman.library_prep_shotgun_process.process_id' x='1043' y='1335' onmouseover="hghl(['library_prep_shotgun_process_fk_shotgun_library_prep_process','labman.process.process_id'])" onmouseout="uhghl(['library_prep_shotgun_process_fk_shotgun_library_prep_process','labman.process.process_id'])">process_id</text><title>process_id
 * integer</title></a>
 <a xlink:href='#library_prep_shotgun_process.process_id'><use id='fk' x='1220' y='1324' xlink:href='#fk'/><title>References process ( process_id ) </title></a>
-  <use id='nn' x='1026' y='1341' xlink:href='#nn'/><a xlink:href='#library_prep_shotgun_process.kappa_hyper_plus_kit_id'><use id='idx' x='1026' y='1340' xlink:href='#idx'/><title>idx_shotgun_library_prep_process_kappa ( kappa_hyper_plus_kit_id ) </title></a>
-<a xlink:href='#library_prep_shotgun_process.kappa_hyper_plus_kit_id'><text id='labman.library_prep_shotgun_process.kappa_hyper_plus_kit_id' x='1043' y='1351' onmouseover="hghl(['library_prep_shotgun_process_fk_shotgun_library_prep_process_kappa','labman.reagent_composition.reagent_composition_id'])" onmouseout="uhghl(['library_prep_shotgun_process_fk_shotgun_library_prep_process_kappa','labman.reagent_composition.reagent_composition_id'])">kappa_hyper_plus_kit_id</text><title>kappa_hyper_plus_kit_id
+  <use id='nn' x='1026' y='1341' xlink:href='#nn'/><a xlink:href='#library_prep_shotgun_process.kapa_hyper_plus_kit_id'><use id='idx' x='1026' y='1340' xlink:href='#idx'/><title>idx_shotgun_library_prep_process_kapa ( kapa_hyper_plus_kit_id ) </title></a>
+<a xlink:href='#library_prep_shotgun_process.kapa_hyper_plus_kit_id'><text id='labman.library_prep_shotgun_process.kapa_hyper_plus_kit_id' x='1043' y='1351' onmouseover="hghl(['library_prep_shotgun_process_fk_shotgun_library_prep_process_kapa','labman.reagent_composition.reagent_composition_id'])" onmouseout="uhghl(['library_prep_shotgun_process_fk_shotgun_library_prep_process_kapa','labman.reagent_composition.reagent_composition_id'])">kapa_hyper_plus_kit_id</text><title>kapa_hyper_plus_kit_id
 * integer</title></a>
-<a xlink:href='#library_prep_shotgun_process.kappa_hyper_plus_kit_id'><use id='fk' x='1220' y='1340' xlink:href='#fk'/><title>References reagent_composition ( kappa_hyper_plus_kit_id -&gt; reagent_composition_id ) </title></a>
+<a xlink:href='#library_prep_shotgun_process.kapa_hyper_plus_kit_id'><use id='fk' x='1220' y='1340' xlink:href='#fk'/><title>References reagent_composition ( kapa_hyper_plus_kit_id -&gt; reagent_composition_id ) </title></a>
   <use id='nn' x='1026' y='1357' xlink:href='#nn'/><a xlink:href='#library_prep_shotgun_process.stub_lot_id'><use id='idx' x='1026' y='1356' xlink:href='#idx'/><title>idx_shotgun_library_prep_process_stub ( stub_lot_id ) </title></a>
 <a xlink:href='#library_prep_shotgun_process.stub_lot_id'><text id='labman.library_prep_shotgun_process.stub_lot_id' x='1043' y='1367' onmouseover="hghl(['library_prep_shotgun_process_fk_shotgun_library_prep_process_stub','labman.reagent_composition.reagent_composition_id'])" onmouseout="uhghl(['library_prep_shotgun_process_fk_shotgun_library_prep_process_stub','labman.reagent_composition.reagent_composition_id'])">stub_lot_id</text><title>stub_lot_id
 * integer
@@ -2612,7 +2612,7 @@ This is sort of like the original targeted_primer_plate table but isn't specific
 	</tr>
 	<tr>
 		<td>*<svg width='14' height='14'><use xlink:href='#idx'/></svg><svg width='14' height='14'><use xlink:href='#fk'/></svg></td>
-		<td><a name='library_prep_shotgun_process.kappa_hyper_plus_kit_id'>kappa&#95;hyper&#95;plus&#95;kit&#95;id</a></td>
+		<td><a name='library_prep_shotgun_process.kapa_hyper_plus_kit_id'>kapa&#95;hyper&#95;plus&#95;kit&#95;id</a></td>
 		<td> integer   </td>
 		<td>  </td>
 	</tr>
@@ -2637,8 +2637,8 @@ This is sort of like the original targeted_primer_plate table but isn't specific
 		<td> ON process&#95;id</td>
 		<td>  </td>
 	</tr>
-	<tr>		<td><svg width='14' height='14'><use xlink:href='#idx'/></svg></td><td>idx&#95;shotgun&#95;library&#95;prep&#95;process&#95;kappa</td>
-		<td> ON kappa&#95;hyper&#95;plus&#95;kit&#95;id</td>
+	<tr>		<td><svg width='14' height='14'><use xlink:href='#idx'/></svg></td><td>idx&#95;shotgun&#95;library&#95;prep&#95;process&#95;kapa</td>
+		<td> ON kapa&#95;hyper&#95;plus&#95;kit&#95;id</td>
 		<td>  </td>
 	</tr>
 	<tr>		<td><svg width='14' height='14'><use xlink:href='#idx'/></svg></td><td>idx&#95;shotgun&#95;library&#95;prep&#95;process&#95;stub</td>
@@ -2656,8 +2656,8 @@ This is sort of like the original targeted_primer_plate table but isn't specific
 		<td>  </td>
 	</tr>
 	<tr>
-		<td><svg width='14' height='14'><use xlink:href='#fk'/></svg></td><td>fk_shotgun_library_prep_process_kappa</td>
-		<td > ( kappa&#95;hyper&#95;plus&#95;kit&#95;id ) ref <a href='#reagent&#95;composition'>reagent&#95;composition</a> (reagent&#95;composition&#95;id) </td>
+		<td><svg width='14' height='14'><use xlink:href='#fk'/></svg></td><td>fk_shotgun_library_prep_process_kapa</td>
+		<td > ( kapa&#95;hyper&#95;plus&#95;kit&#95;id ) ref <a href='#reagent&#95;composition'>reagent&#95;composition</a> (reagent&#95;composition&#95;id) </td>
 		<td>  </td>
 	</tr>
 	<tr>

--- a/labcontrol/db/support_files/populate_test_db.sql
+++ b/labcontrol/db/support_files/populate_test_db.sql
@@ -438,7 +438,7 @@ BEGIN
         VALUES (water_composition_id, water_reagent_comp_type, 'RNBF7110')
         RETURNING reagent_composition_id INTO water_reagent_composition_id;
 
-    -- Kappa Hyper Plus kit
+    -- Kapa Hyper Plus kit
     INSERT INTO labman.process (process_type_id, run_date, run_personnel_id)
         VALUES (rc_process_type_id, '10/23/2017 09:10:25', 'test@foo.bar')
         RETURNING process_id INTO rc_process_id_khp;
@@ -452,7 +452,7 @@ BEGIN
 
     SELECT reagent_composition_type_id INTO khp_reagent_comp_type
         FROM labman.reagent_composition_type
-        WHERE description = 'kappa hyper plus kit';
+        WHERE description = 'kapa hyper plus kit';
 
     INSERT INTO labman.composition (composition_type_id, upstream_process_id, container_id, total_volume)
         VALUES (reagent_comp_type, rc_process_id_khp, khp_container_id, 10)
@@ -803,7 +803,7 @@ BEGIN
         VALUES (shotgun_lib_process_type_id, '10/25/2017 19:10:25', 'test@foo.bar')
         RETURNING process_id INTO shotgun_lib_process_id;
 
-    INSERT INTO labman.library_prep_shotgun_process (process_id, kappa_hyper_plus_kit_id, stub_lot_id, normalization_process_id)
+    INSERT INTO labman.library_prep_shotgun_process (process_id, kapa_hyper_plus_kit_id, stub_lot_id, normalization_process_id)
         VALUES (shotgun_lib_process_id, khp_reagent_composition_id, stubs_reagent_composition_id, gdna_norm_subprocess_id);
 
     INSERT INTO labman.plate (external_id, plate_configuration_id)

--- a/labcontrol/db/tests/test_process.py
+++ b/labcontrol/db/tests/test_process.py
@@ -1052,7 +1052,7 @@ class TestLibraryPrepShotgunProcess(LabControlTestCase):
                          _help_make_datetime('2017-10-25 19:10:25'))
         self.assertEqual(tester.personnel, User('test@foo.bar'))
         self.assertEqual(tester.process_id, 22)
-        self.assertEqual(tester.kappa_hyper_plus_kit, ReagentComposition(5))
+        self.assertEqual(tester.kapa_hyper_plus_kit, ReagentComposition(5))
         self.assertEqual(tester.stub_lot, ReagentComposition(6))
         self.assertEqual(tester.normalization_process, NormalizationProcess(1))
         self.assertEqual(tester.normalized_plate, Plate(25))
@@ -1063,14 +1063,14 @@ class TestLibraryPrepShotgunProcess(LabControlTestCase):
     def test_create(self):
         user = User('test@foo.bar')
         plate = Plate(25)
-        kappa = ReagentComposition(4)
+        kapa = ReagentComposition(4)
         stub = ReagentComposition(5)
         obs = LibraryPrepShotgunProcess.create(
-            user, plate, 'Test Shotgun Library 1', kappa, stub, 4000,
+            user, plate, 'Test Shotgun Library 1', kapa, stub, 4000,
             Plate(19), Plate(20))
         self.assertTrue(_help_compare_timestamps(obs.date))
         self.assertEqual(obs.personnel, user)
-        self.assertEqual(obs.kappa_hyper_plus_kit, kappa)
+        self.assertEqual(obs.kapa_hyper_plus_kit, kapa)
         self.assertEqual(obs.stub_lot, stub)
         self.assertEqual(obs.normalization_process, NormalizationProcess(1))
         self.assertEqual(obs.normalized_plate, Plate(25))

--- a/labcontrol/db/tests/tester.py
+++ b/labcontrol/db/tests/tester.py
@@ -162,11 +162,11 @@ def create_normalization_process(user, quant_process):
 
 
 def create_shotgun_process(user, norm_plate):
-    kappa = ReagentComposition(4)
+    kapa = ReagentComposition(4)
     stub = ReagentComposition(5)
     primer_a, primer_b = get_primer_plate(is_96=False)
     shotgun_process = LibraryPrepShotgunProcess.create(
-        user, norm_plate, 'Test Shotgun Library %s' % datetime.now(), kappa,
+        user, norm_plate, 'Test Shotgun Library %s' % datetime.now(), kapa,
         stub, 4000, primer_a, primer_b)
     shotgun_plate = shotgun_process.plates[0]
     return shotgun_process, shotgun_plate

--- a/labcontrol/gui/handlers/process_handlers/library_prep_shotgun_process.py
+++ b/labcontrol/gui/handlers/process_handlers/library_prep_shotgun_process.py
@@ -21,7 +21,7 @@ class LibraryPrepShotgunProcessHandler(BaseHandler):
     def get(self):
         plate_ids = self.get_arguments('plate_id')
         process_id = self.get_argument('process_id', None)
-        kappa = None
+        kapa = None
         stub = None
         volume = None
         norm_plate = None
@@ -33,7 +33,7 @@ class LibraryPrepShotgunProcessHandler(BaseHandler):
             except LabControlUnknownIdError:
                 raise HTTPError(404, reason="Shotgun library prep process %s "
                                             "doesn't exist" % process_id)
-            kappa = process.kappa_hyper_plus_kit.external_lot_id
+            kapa = process.kapa_hyper_plus_kit.external_lot_id
             stub = process.stub_lot.external_lot_id
             norm_plate = process.normalized_plate.id
             i5plate = process.i5_primer_plate.id
@@ -48,7 +48,7 @@ class LibraryPrepShotgunProcessHandler(BaseHandler):
 
         self.render('library_prep_shotgun.html', plate_ids=plate_ids,
                     primer_plates=primer_plates, process_id=process_id,
-                    kappa=kappa, stub=stub, volume=volume,
+                    kapa=kapa, stub=stub, volume=volume,
                     norm_plate=norm_plate, i5plate=i5plate, i7plate=i7plate)
 
     @authenticated
@@ -56,13 +56,13 @@ class LibraryPrepShotgunProcessHandler(BaseHandler):
         user = self.current_user
         plates_info = self.get_argument('plates_info')
         volume = self.get_argument('volume')
-        kappa_hyper_plus_kit = self.get_argument('kappa_hyper_plus_kit')
+        kapa_hyper_plus_kit = self.get_argument('kapa_hyper_plus_kit')
         stub_lot = self.get_argument('stub_lot')
 
         processes = [
             [pid, LibraryPrepShotgunProcess.create(
                 user, Plate(pid), plate_name,
-                ReagentComposition.from_external_id(kappa_hyper_plus_kit),
+                ReagentComposition.from_external_id(kapa_hyper_plus_kit),
                 ReagentComposition.from_external_id(stub_lot), volume,
                 Plate(i5p), Plate(i7p)).id]
             for pid, plate_name, i5p, i7p in json_decode(plates_info)]

--- a/labcontrol/gui/handlers/process_handlers/test/test_library_prep_shotgun_process.py
+++ b/labcontrol/gui/handlers/process_handlers/test/test_library_prep_shotgun_process.py
@@ -36,7 +36,7 @@ class TestLibraryPrepShotgunProcessHandler(TestHandlerBase):
 
     def test_post_library_prep_shotgun_process_handler(self):
         data = {'plates_info': json_encode([[25, 'my new plate', 19, 20]]),
-                'volume': 50, 'kappa_hyper_plus_kit': 'KHP1',
+                'volume': 50, 'kapa_hyper_plus_kit': 'KHP1',
                 'stub_lot': 'STUBS1'}
         response = self.post('/process/library_prep_shotgun', data)
         self.assertEqual(response.code, 200)

--- a/labcontrol/gui/templates/library_prep_shotgun.html
+++ b/labcontrol/gui/templates/library_prep_shotgun.html
@@ -14,7 +14,7 @@
     var plateIds = {% raw plate_ids %};
     if (processId !== null) {
       bootstrapAlert('Loading data...', 'info');
-      $('#kappa_hyper_plus_kit-input').val('{{kappa}}');
+      $('#kapa_hyper_plus_kit-input').val('{{kapa}}');
       $('#stubs-input').val('{{stub}}');
       $('#volume-input').val('{{volume}}');
       // Add the plate
@@ -59,7 +59,7 @@
     var postData = {
         'volume': $('#volume-input').val(),
         'plates_info': JSON.stringify(platesInfo),
-        'kappa_hyper_plus_kit': $('#kappa_hyper_plus_kit-input').val(),
+        'kapa_hyper_plus_kit': $('#kapa_hyper_plus_kit-input').val(),
         'stub_lot': $('#stubs-input').val()};
     $.post('/process/library_prep_shotgun', postData, function(data) {
       bootstrapAlert('Information saved', 'success');
@@ -84,7 +84,7 @@
     if (plates.length === 0) {
       $('#library-prep-btn').prop('disabled', true);
     } else {
-      var disabled = ($('#kappa_hyper_plus_kit-input').val() === '' ||
+      var disabled = ($('#kapa_hyper_plus_kit-input').val() === '' ||
                       $('#stubs-input').val() === '' ||
                       $('#volume-input').val() === '0');
       $.each(plates, function(idx, elem) {
@@ -147,7 +147,7 @@
   $(document).ready(function() {
     setUpAddPlateModal(['normalized gDNA'], false);
 
-    $('#kappa_hyper_plus_kit-input').on('change', libraryPrepChecks);
+    $('#kapa_hyper_plus_kit-input').on('change', libraryPrepChecks);
     $('#stubs-input').on('change', libraryPrepChecks);
     $('#volume-input').on('change', libraryPrepChecks);
 
@@ -171,10 +171,10 @@
   <div id='plate-list'></div>
 </div>
 
-<!-- kappa hyper plus kit -->
+<!-- kapa hyper plus kit -->
 <div class='form-group'>
-  <label class='control-label'><h4>Kappa hyper plus kit:</h4></label>
-  <input type='text' id='kappa_hyper_plus_kit-input' class='form-control' />
+  <label class='control-label'><h4>Kapa hyper plus kit:</h4></label>
+  <input type='text' id='kapa_hyper_plus_kit-input' class='form-control' />
 </div>
 
 <!-- stub lot -->
@@ -194,7 +194,7 @@
 </div>
 
 <div id='vue-element'>
-  <reagent-modal id-prefix="kappa" reagent-type="kappa hyper plus kit" input-target="kappa_hyper_plus_kit-input" v-bind:checks-callback="libraryPrepChecks"></reagent-modal>
+  <reagent-modal id-prefix="kapa" reagent-type="kapa hyper plus kit" input-target="kapa_hyper_plus_kit-input" v-bind:checks-callback="libraryPrepChecks"></reagent-modal>
   <reagent-modal id-prefix="stubs" reagent-type="shotgun stubs" input-target="stubs-input" v-bind:checks-callback="libraryPrepChecks"></reagent-modal>
 </div>
 


### PR DESCRIPTION
The correct terminology for this kit is 'Kapa Hyper Plus' kit. This is a work in progress to rename all database columns, html instances, variable names, etc. without considering patching (yet).