### PR TITLE
Modified pooling_process.py to support new miniPCR

### DIFF
--- a/labcontrol/gui/handlers/process_handlers/pooling_process.py
+++ b/labcontrol/gui/handlers/process_handlers/pooling_process.py
@@ -376,7 +376,8 @@ class LibraryPool16SProcessHandler(BasePoolHandler):
 
             # calculate estimated molar fraction for each element of pool
             amts = plate_result['comp_vals'] * plate_result['pool_vals']
-            pcts = amts / amts.sum()
+            total = amts.sum()
+            pcts = amts / total
 
             quant_process = QuantificationProcess(
                 plate_result['quant-process-id'])


### PR DESCRIPTION
Refactor helper function that is only used in two locations and is very
small, in order to increase encapsulation. (Note this is reintroducing
this patch from George's original version.)

Note this fix is small but isolated and as a sanity check it will be useful to see it run through unittests successfully.