### PR TITLE
Client-side specimen ID matching

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -2,6 +2,7 @@
 branch = True
 omit =
     */tests*
+    */test*
     */__init__.py
     labcontrol/_version.py
     versioneer.py
@@ -9,6 +10,7 @@ omit =
 [report]
 omit =
     */tests*
+    */test*
     */__init__.py
     labcontrol/_version.py
     versioneer.py

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # LabControl
 [![Build Status](https://travis-ci.org/biocore/LabControl.svg?branch=master)](https://travis-ci.org/biocore/LabControl)
+
 lab manager for plate maps and sequence flows
 
 # Install

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # LabControl
-[![Build Status](https://travis-ci.org/biocore/LabControl.svg?branch=master)](https://travis-ci.org/biocore/LabControl)
+[![Build Status](https://travis-ci.org/biocore/LabControl.svg?branch=master)](https://travis-ci.org/biocore/LabControl) [![Coverage Status](https://coveralls.io/repos/github/biocore/LabControl/badge.svg?branch=master)](https://coveralls.io/github/biocore/LabControl?branch=master)
 
 lab manager for plate maps and sequence flows
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # LabControl
+[![Build Status](https://travis-ci.org/biocore/LabControl.svg?branch=master)](https://travis-ci.org/biocore/LabControl)
 lab manager for plate maps and sequence flows
 
 # Install

--- a/labcontrol/db/process.py
+++ b/labcontrol/db/process.py
@@ -296,10 +296,9 @@ class SamplePlatingProcess(_Process):
 
         Returns
         -------
-        str
-            The new contents of the well
-        bool
-            Whether or not the new contents of the well are "ok"
+        (str, bool)
+            The str corresponds to the new contents of the well; the bool
+            indicates whether or not the new contents of the well are "ok"
         """
         return self.plate.get_well(row, col).composition.update(content)
 

--- a/labcontrol/db/process.py
+++ b/labcontrol/db/process.py
@@ -298,6 +298,8 @@ class SamplePlatingProcess(_Process):
         -------
         str
             The new contents of the well
+        bool
+            Whether or not the new contents of the well are "ok"
         """
         return self.plate.get_well(row, col).composition.update(content)
 

--- a/labcontrol/db/study.py
+++ b/labcontrol/db/study.py
@@ -223,6 +223,10 @@ class Study(base.LabControlObject):
             order_by_clause = "order by sample_values->'%s'" % column
 
         if limit:
+            # if this fails it'll propagate up as expected
+            limit = int(limit)
+            if limit <= 0:
+                raise ValueError("limit can't be <= 0")
             order_by_clause += " limit %d" % limit
 
         if column == 'sample_id':

--- a/labcontrol/db/study.py
+++ b/labcontrol/db/study.py
@@ -233,9 +233,11 @@ class Study(base.LabControlObject):
             # that the integer limit is greater than zero
             try:
                 limit = int(limit)
-            except (ValueError, OverflowError):
-                # The OverflowError can happen if the user passes in
-                # float("inf") or float("-inf") as the limit
+            except (ValueError, OverflowError, TypeError):
+                # Examples of why we catch these particular exceptions:
+                # - ValueError is most "common," occurs with int("abc")
+                # - OverflowError occurs with int(float("inf"))
+                # - TypeError occurs with int([1,2,3])
                 raise ValueError("limit must be castable to an int")
             if limit <= 0:
                 raise ValueError("limit must be greater than zero")

--- a/labcontrol/db/study.py
+++ b/labcontrol/db/study.py
@@ -233,11 +233,13 @@ class Study(base.LabControlObject):
             # that the integer limit is greater than zero
             try:
                 limit = int(limit)
-            except (ValueError, OverflowError, TypeError):
-                # Examples of why we catch these particular exceptions:
+            except Exception:
+                # Examples of possible exceptions due to int(limit) failing:
                 # - ValueError is most "common," occurs with int("abc")
                 # - OverflowError occurs with int(float("inf"))
                 # - TypeError occurs with int([1,2,3])
+                # This should catch all of the above and any other exceptions
+                # raised due to int(limit) failing.
                 raise ValueError("limit must be castable to an int")
             if limit <= 0:
                 raise ValueError("limit must be greater than zero")

--- a/labcontrol/db/study.py
+++ b/labcontrol/db/study.py
@@ -198,6 +198,11 @@ class Study(base.LabControlObject):
         list of str
             Returns tube identifiers if the `specimen_id_column` has been set
             (in Qiita), or alternatively returns the sample identifier.
+
+        Raises
+        ------
+        ValueError
+            If `type(limit) != int`, or if `limit` is less than or equal to 0.
         """
 
         # SQL generation moved outside of the with conditional to enhance
@@ -222,9 +227,9 @@ class Study(base.LabControlObject):
         else:
             order_by_clause = "order by sample_values->'%s'" % column
 
-        if limit:
-            # if this fails it'll propagate up as expected
-            limit = int(limit)
+        if limit is not None:
+            if type(limit) != int:
+                raise ValueError("limit must be an int")
             if limit <= 0:
                 raise ValueError("limit can't be <= 0")
             order_by_clause += " limit %d" % limit

--- a/labcontrol/db/tests/test_study.py
+++ b/labcontrol/db/tests/test_study.py
@@ -83,6 +83,45 @@ class TestStudy(LabControlTestCase):
         exp_samples = ['1.SKB1.640202', '1.SKD1.640179', '1.SKM1.640183']
         self.assertEqual(s.samples('1.64'), exp_samples)
 
+    def test_samples_with_limit(self):
+        s = Study(1)
+        all_samples = ['1.SKB1.640202', '1.SKB2.640194', '1.SKB3.640195',
+                       '1.SKB4.640189', '1.SKB5.640181', '1.SKB6.640176',
+                       '1.SKB7.640196', '1.SKB8.640193', '1.SKB9.640200',
+                       '1.SKD1.640179', '1.SKD2.640178', '1.SKD3.640198',
+                       '1.SKD4.640185', '1.SKD5.640186', '1.SKD6.640190',
+                       '1.SKD7.640191', '1.SKD8.640184', '1.SKD9.640182',
+                       '1.SKM1.640183', '1.SKM2.640199', '1.SKM3.640197',
+                       '1.SKM4.640180', '1.SKM5.640177', '1.SKM6.640187',
+                       '1.SKM7.640188', '1.SKM8.640201', '1.SKM9.640192']
+        # Check cases where the limit is valid but doesn't actually result in
+        # any filtering being done.
+        self.assertEqual(s.samples(), all_samples)
+        self.assertEqual(s.samples(limit=None), all_samples)
+        self.assertEqual(s.samples(limit=27), all_samples)
+        self.assertEqual(s.samples(limit=28), all_samples)
+        self.assertEqual(s.samples(limit=50), all_samples)
+        self.assertEqual(s.samples(limit=100), all_samples)
+        self.assertEqual(s.samples(limit=10000), all_samples)
+        # limit=None is the default, but we check it here explicitly anyway
+        self.assertEqual(s.samples(limit=None), all_samples)
+
+        # Check *all* limit values in the inclusive range [1, 27]
+        for i in range(1, len(all_samples)):
+            self.assertEqual(s.samples(limit=i), all_samples[:i])
+
+        # Check that non-int limits cause an error
+        nonint_limits_to_test = [0.01, 0.5, 1.0, 1.2, 3.0, 27.0, 29.1, 1000.0]
+        nonint_limits_to_test += [[1, 2, 3], "abc", "123", "1"]
+        for i in nonint_limits_to_test:
+            with self.assertRaisesRegex(ValueError, "limit must be an int"):
+                s.samples(limit=i)
+
+        # Check that limits <= 0 cause an error
+        for i in range(0, -len(all_samples), -1):
+            with self.assertRaisesRegex(ValueError, "limit can't be <= 0"):
+                s.samples(limit=i)
+
     def test_samples_with_specimen_id(self):
         s = Study(1)
 

--- a/labcontrol/db/tests/test_study.py
+++ b/labcontrol/db/tests/test_study.py
@@ -155,6 +155,10 @@ class TestStudy(LabControlTestCase):
                 ValueError, "limit must be greater than zero"
             ):
                 s.samples(limit=i)
+            with self.assertRaisesRegex(
+                ValueError, "limit must be greater than zero"
+            ):
+                s.samples(limit=str(i))
 
         # Check evil corner case where the limit is nonpositive and not
         # castable to an int (this should fail first on the castable check)

--- a/labcontrol/db/tests/test_study.py
+++ b/labcontrol/db/tests/test_study.py
@@ -6,6 +6,7 @@
 # The full license is in the file LICENSE, distributed with this software.
 # ----------------------------------------------------------------------------
 
+from math import floor
 from unittest import main
 
 from labcontrol.db.testing import LabControlTestCase
@@ -65,13 +66,13 @@ class TestStudy(LabControlTestCase):
         exp_samples = ['1.SKB1.640202', '1.SKB2.640194', '1.SKB3.640195',
                        '1.SKB4.640189', '1.SKB5.640181', '1.SKB6.640176',
                        '1.SKB7.640196', '1.SKB8.640193', '1.SKB9.640200']
-        self.assertEqual(s.samples(limit=9), exp_samples)
+        self.assertEqual(s.samples(limit='9'), exp_samples)
         exp_samples = ['1.SKB1.640202', '1.SKB2.640194', '1.SKB3.640195',
                        '1.SKB4.640189', '1.SKB5.640181', '1.SKB6.640176',
                        '1.SKB7.640196', '1.SKB8.640193', '1.SKB9.640200']
         self.assertEqual(s.samples('SKB'), exp_samples)
         exp_samples = ['1.SKB1.640202', '1.SKB2.640194', '1.SKB3.640195']
-        self.assertEqual(s.samples('SKB', limit=3), exp_samples)
+        self.assertEqual(s.samples('SKB', limit='3'), exp_samples)
         exp_samples = ['1.SKM1.640183', '1.SKM2.640199', '1.SKM3.640197',
                        '1.SKM4.640180', '1.SKM5.640177', '1.SKM6.640187',
                        '1.SKM7.640188', '1.SKM8.640201', '1.SKM9.640192']
@@ -84,6 +85,17 @@ class TestStudy(LabControlTestCase):
         self.assertEqual(s.samples('1.64'), exp_samples)
 
     def test_samples_with_limit(self):
+        """Unit-tests the `limit` argument of Study.samples() in particular.
+
+        It's worth noting that the `limit` value that StudySamplesHandler.get()
+        uses when calling Study.samples() is actually a string -- this is due
+        to our use of tornado.web.RequestHandler.get_argument().
+        Study.samples() only cares that `int(limit)` succeeds, and is otherwise
+        agnostic to the actual input type of `limit`.
+
+        (For the sake of caution, we test a couple of types besides purely
+        `str` values within this function.)
+        """
         s = Study(1)
         all_samples = ['1.SKB1.640202', '1.SKB2.640194', '1.SKB3.640195',
                        '1.SKB4.640189', '1.SKB5.640181', '1.SKB6.640176',
@@ -97,30 +109,59 @@ class TestStudy(LabControlTestCase):
         # Check cases where the limit is valid but doesn't actually result in
         # any filtering being done.
         self.assertEqual(s.samples(), all_samples)
-        self.assertEqual(s.samples(limit=None), all_samples)
-        self.assertEqual(s.samples(limit=27), all_samples)
-        self.assertEqual(s.samples(limit=28), all_samples)
-        self.assertEqual(s.samples(limit=50), all_samples)
-        self.assertEqual(s.samples(limit=100), all_samples)
-        self.assertEqual(s.samples(limit=10000), all_samples)
-        # limit=None is the default, but we check it here explicitly anyway
+        for i in [27, 28, 50, 100, 10000]:
+            self.assertEqual(s.samples(limit=i), all_samples)
+            self.assertEqual(s.samples(limit=str(i)), all_samples)
+        # limit=None is the default, but we check it here explicitly anyway.
         self.assertEqual(s.samples(limit=None), all_samples)
 
-        # Check *all* limit values in the inclusive range [1, 27]
+        # Check *all* limit values in the inclusive range [1, 27] -- these
+        # should, well, limit the output list of samples accordingly
         for i in range(1, len(all_samples)):
             self.assertEqual(s.samples(limit=i), all_samples[:i])
+            self.assertEqual(s.samples(limit=str(i)), all_samples[:i])
 
-        # Check that non-int limits cause an error
-        nonint_limits_to_test = [0.01, 0.5, 1.0, 1.2, 3.0, 27.0, 29.1, 1000.0]
-        nonint_limits_to_test += [[1, 2, 3], "abc", "123", "1"]
-        for i in nonint_limits_to_test:
-            with self.assertRaisesRegex(ValueError, "limit must be an int"):
+        float_limits_to_test = [1.0, 1.2, 3.0, 27.0, 29.1, 1000.0]
+        str_of_float_limits_to_test = [str(f) for f in float_limits_to_test]
+
+        # Test that various not-castable-to-a-base-10-int inputs don't work
+        # (This includes string representations of floats, e.g. "1.0", since
+        # such a string is not a valid "integer literal" -- see
+        # https://docs.python.org/3/library/functions.html#int.
+        uncastable_limits_to_test = [
+            [1, 2, 3], "abc", "gibberish", "ten", (1,), "0xBEEF", "0b10101",
+            "0o123", float("inf"), float("-inf"), float("nan"), "None", "inf"
+        ]
+        for i in uncastable_limits_to_test + str_of_float_limits_to_test:
+            with self.assertRaisesRegex(
+                ValueError, "limit must be castable to an int"
+            ):
                 s.samples(limit=i)
+
+        # Calling int(x) where x is a float just truncates x "towards zero"
+        # according to https://docs.python.org/3/library/functions.html#int.
+        #
+        # This behavior is tested, but it should never happen (one, because
+        # as of writing Study.samples() is only called with a string limit
+        # value, and two because I can't imagine why someone would pass a float
+        # in for the "limit" argument).
+        for i in float_limits_to_test:
+            self.assertEqual(s.samples(limit=i), all_samples[:floor(i)])
 
         # Check that limits <= 0 cause an error
-        for i in range(0, -len(all_samples), -1):
-            with self.assertRaisesRegex(ValueError, "limit can't be <= 0"):
+        nonpositive_limits = [0, -1, -2, -27, -53, -100]
+        for i in nonpositive_limits:
+            with self.assertRaisesRegex(
+                ValueError, "limit must be greater than zero"
+            ):
                 s.samples(limit=i)
+
+        # Check evil corner case where the limit is nonpositive and not
+        # castable to an int (this should fail first on the castable check)
+        with self.assertRaisesRegex(
+            ValueError, "limit must be castable to an int"
+        ):
+            s.samples(limit="-1.0")
 
     def test_samples_with_specimen_id(self):
         s = Study(1)

--- a/labcontrol/gui/handlers/study.py
+++ b/labcontrol/gui/handlers/study.py
@@ -50,12 +50,24 @@ class StudySamplesHandler(BaseHandler):
         try:
             study = Study(int(study_id))
             term = self.get_argument('term', None)
-            # Default limit is None (i.e. give back all samples).
+
+            # Default limit is None (i.e. give back all samples)
             limit = self.get_argument('limit', None)
+            if limit is not None:
+                # If this fails, it'll result in a ValueError
+                limit = int(limit)
+
+            # If limit is somehow invalid (<= 0 or not an int), study.samples()
+            # will raise a ValueError. The interpretation is the same as with
+            # the possible ValueError raised on int(limit) -- the limit is
+            # invalid, so we'll set a 400 ("Bad Request") status code.
             res = list(study.samples(term, limit))
             self.write(json_encode(res))
         except LabControlUnknownIdError:
             self.set_status(404)
+        except ValueError:
+            # These will be raised if the limit passed is invalid
+            self.set_status(400)
         self.finish()
 
 

--- a/labcontrol/gui/handlers/study.py
+++ b/labcontrol/gui/handlers/study.py
@@ -50,17 +50,10 @@ class StudySamplesHandler(BaseHandler):
         try:
             study = Study(int(study_id))
             term = self.get_argument('term', None)
-
-            # Default limit is None (i.e. give back all samples)
             limit = self.get_argument('limit', None)
-            if limit is not None:
-                # If this fails, it'll result in a ValueError
-                limit = int(limit)
-
-            # If limit is somehow invalid (<= 0 or not an int), study.samples()
-            # will raise a ValueError. The interpretation is the same as with
-            # the possible ValueError raised on int(limit) -- the limit is
-            # invalid, so we'll set a 400 ("Bad Request") status code.
+            # If the specified limit is somehow invalid, study.samples() will
+            # raise a ValueError. In this case, we'll set a 400 ("Bad Request")
+            # status code.
             res = list(study.samples(term, limit))
             self.write(json_encode(res))
         except LabControlUnknownIdError:

--- a/labcontrol/gui/handlers/study.py
+++ b/labcontrol/gui/handlers/study.py
@@ -50,7 +50,9 @@ class StudySamplesHandler(BaseHandler):
         try:
             study = Study(int(study_id))
             term = self.get_argument('term', None)
-            res = list(study.samples(term, limit=20))
+            # Default limit is None (i.e. give back all samples).
+            limit = self.get_argument('limit', None)
+            res = list(study.samples(term, limit))
             self.write(json_encode(res))
         except LabControlUnknownIdError:
             self.set_status(404)

--- a/labcontrol/gui/js_tests/labcontrol_tests.js
+++ b/labcontrol/gui/js_tests/labcontrol_tests.js
@@ -79,3 +79,32 @@ QUnit.module("clippingForPlateType", function(hooks) {
     assert.equal(clippingForPlateType("not a valid type"), 10000);
   });
 });
+
+QUnit.module("getSubstringMatches", function(hooks) {
+  QUnit.test("common usage", function(assert) {
+    assert.propEqual(getSubstringMatches("w", ["wahoo", "walrus"]), [
+      "wahoo",
+      "walrus"
+    ]);
+    assert.propEqual(getSubstringMatches("h", ["wahoo", "walrus"]), ["wahoo"]);
+    assert.equal(getSubstringMatches("z", ["wahoo", "walrus"]).length, 0);
+    assert.propEqual(getSubstringMatches("1234f", ["01234f", "01234"]), [
+      "01234f"
+    ]);
+    assert.propEqual(
+      getSubstringMatches("abc", ["abc", "ABCDEF", "AbCdE", "", "DEF"]),
+      ["abc", "ABCDEF", "AbCdE"]
+    );
+  });
+  QUnit.test("empty query text and/or empty strings in array", function(
+    assert
+  ) {
+    assert.equal(getSubstringMatches("", ["wahoo", "walrus"]).length, 0);
+    assert.equal(getSubstringMatches("", ["wahoo", "walrus", ""]).length, 0);
+    assert.equal(getSubstringMatches("abc", ["wahoo", "walrus", ""]).length, 0);
+    assert.propEqual(getSubstringMatches("w", ["wahoo", "walrus", ""]), [
+      "wahoo",
+      "walrus"
+    ]);
+  });
+});

--- a/labcontrol/gui/js_tests/labcontrol_tests.js
+++ b/labcontrol/gui/js_tests/labcontrol_tests.js
@@ -82,16 +82,16 @@ QUnit.module("clippingForPlateType", function(hooks) {
 
 QUnit.module("getSubstringMatches", function(hooks) {
   QUnit.test("common usage", function(assert) {
-    assert.propEqual(getSubstringMatches("w", ["wahoo", "walrus"]), [
+    assert.deepEqual(getSubstringMatches("w", ["wahoo", "walrus"]), [
       "wahoo",
       "walrus"
     ]);
-    assert.propEqual(getSubstringMatches("h", ["wahoo", "walrus"]), ["wahoo"]);
+    assert.deepEqual(getSubstringMatches("h", ["wahoo", "walrus"]), ["wahoo"]);
     assert.equal(getSubstringMatches("z", ["wahoo", "walrus"]).length, 0);
-    assert.propEqual(getSubstringMatches("1234f", ["01234f", "01234"]), [
+    assert.deepEqual(getSubstringMatches("1234f", ["01234f", "01234"]), [
       "01234f"
     ]);
-    assert.propEqual(
+    assert.deepEqual(
       getSubstringMatches("abc", ["abc", "ABCDEF", "AbCdE", "", "DEF"]),
       ["abc", "ABCDEF", "AbCdE"]
     );
@@ -102,7 +102,7 @@ QUnit.module("getSubstringMatches", function(hooks) {
     assert.equal(getSubstringMatches("", ["wahoo", "walrus"]).length, 0);
     assert.equal(getSubstringMatches("", ["wahoo", "walrus", ""]).length, 0);
     assert.equal(getSubstringMatches("abc", ["wahoo", "walrus", ""]).length, 0);
-    assert.propEqual(getSubstringMatches("w", ["wahoo", "walrus", ""]), [
+    assert.deepEqual(getSubstringMatches("w", ["wahoo", "walrus", ""]), [
       "wahoo",
       "walrus"
     ]);

--- a/labcontrol/gui/static/js/labcontrol.js
+++ b/labcontrol/gui/static/js/labcontrol.js
@@ -746,7 +746,8 @@ function createHeatmap(
 /**
  *
  * Given a query string and an array of strings to search through, returns a
- * subset of the array containing only strings that contain the query string.
+ * subset of the array containing only strings that contain the query string
+ * (or an empty array, if no such matches are found).
  *
  * This search is case insensitive, so "abc" will match with "ABCDEF".
  *

--- a/labcontrol/gui/static/js/labcontrol.js
+++ b/labcontrol/gui/static/js/labcontrol.js
@@ -742,3 +742,36 @@ function createHeatmap(
     });
   });
 }
+
+/**
+ *
+ * Given a query string and an array of strings to search through, returns a
+ * subset of the array containing only strings that contain the query string.
+ *
+ * This search is case insensitive, so "abc" will match with "ABCDEF".
+ *
+ * Note that if queryString is empty (i.e. "") then this won't return any
+ * matches, even if "" is present in stringArray for some reason (since
+ * stringArray should be a list of sample IDs, this should never be the case).
+ *
+ * This function is loosely based on textFilterFeatures() in Qurro:
+ * https://github.com/biocore/qurro/blob/3f4650fb677753e978d971b06794d4790b051d30/qurro/support_files/js/feature_computation.js#L29
+ *
+ * @param {string} queryString The string that will be searched for
+ * @param {array} stringArray Collection of strings to check against the query
+ * @returns {array} Collection of strings in stringArray that include the query
+ *
+ */
+function getSubstringMatches(queryString, stringArray) {
+  if (queryString.length === 0 || stringArray.length === []) {
+    return [];
+  }
+  var queryStringLowerCase = queryString.toLowerCase();
+  var matchingStrings = [];
+  for (var i = 0; i < stringArray.length; i++) {
+    if (stringArray[i].toLowerCase().includes(queryStringLowerCase)) {
+      matchingStrings.push(stringArray[i]);
+    }
+  }
+  return matchingStrings;
+}

--- a/labcontrol/gui/static/js/plate.js
+++ b/labcontrol/gui/static/js/plate.js
@@ -119,7 +119,7 @@ function activate_study(studyId) {
  *
  **/
 function change_plate_configuration() {
-  var pv, $opt;
+  var $opt;
   $opt = $("#plate-conf-select option:selected");
   var plateId = $("#plateName").prop("pm-data-plate-id");
   if (plateId !== undefined) {

--- a/labcontrol/gui/static/js/plateViewer.js
+++ b/labcontrol/gui/static/js/plateViewer.js
@@ -470,16 +470,17 @@ function getSubstringMatches(queryString, stringArray) {
 /**
  *
  * Actually updates a well's content in the backend. This code was ripped out
- * of PlateViewer.modifyWell() so that it could be called multiple times.
+ * of PlateViewer.modifyWell().
  *
  * @param {int} row The row of the well being modified
  * @param {int} col The column of the well being modified
  * @param {string} content The new content of the well
+ * @param {string} studyID The output of getActiveStudy() -- this paradigm
+ *      should really be changed in the future to accommodate multiple studies.
  *
  */
-PlateViewer.prototype.patchWell = function(row, col, content) {
-  var that = this,
-    studyID = this.getActiveStudy();
+PlateViewer.prototype.patchWell = function(row, col, content, studyID) {
+  var that = this;
 
   $.ajax({
     url: "/process/sample_plating/" + this.processId,
@@ -543,7 +544,7 @@ PlateViewer.prototype.modifyWell = function(row, col, content) {
     } else {
       console.log("Couldn't resolve", content);
     }
-    that.patchWell(row, col, possiblyNewContent);
+    that.patchWell(row, col, possiblyNewContent, studyID);
   });
 };
 

--- a/labcontrol/gui/static/js/plateViewer.js
+++ b/labcontrol/gui/static/js/plateViewer.js
@@ -456,10 +456,6 @@ PlateViewer.prototype.patchWell = function(row, col, content, studyID) {
     },
     success: function(data) {
       that.data[row][that.grid.getColumns()[col].field] = data["sample_id"];
-      // NOTE: this pretty much checks the status of every well, and this is
-      // called in patchWell (i.e. every time a well is updated). Should be a
-      // lot more efficient to minimize the impact of this by just checking for
-      // changes relative to this well?
       that.updateUnknownsAndDuplicates();
       var classIdx = that.wellClasses[row][col].indexOf("well-prev-plated");
       if (data["previous_plates"].length > 0) {

--- a/labcontrol/gui/static/js/plateViewer.js
+++ b/labcontrol/gui/static/js/plateViewer.js
@@ -804,10 +804,10 @@ function autocomplete_search_samples(request, response) {
 
   $.when.apply($, requests).then(
     function() {
-      // The nature of arguments change based on the number of requests performed
-      // If only one request was performed, then arguments only contain the output
-      // of that request. On the other hand, if there was more than one request,
-      // then arguments is a list of results
+      // The nature of arguments change based on the number of requests
+      // performed. If only one request was performed, then arguments only
+      // contain the output of that request. On the other hand, if there was
+      // more than one request, then arguments is a list of results
       var arg = requests.length === 1 ? [arguments] : arguments;
       var samples = merge_sample_responses(arg);
       // Format the samples in the way that autocomplete needs
@@ -909,6 +909,10 @@ function get_active_samples() {
     // array of all sample IDs from all active studies.
     return $.when.apply($, requests).then(
       function() {
+        // The nature of arguments change based on the number of requests
+        // performed. If only one request was performed, then arguments only
+        // contain the output of that request. On the other hand, if there was
+        // more than one request, then arguments is a list of results
         var arg = requests.length === 1 ? [arguments] : arguments;
         return merge_sample_responses(arg);
       },

--- a/labcontrol/gui/static/js/plateViewer.js
+++ b/labcontrol/gui/static/js/plateViewer.js
@@ -496,10 +496,12 @@ PlateViewer.prototype.modifyWell = function(row, col, content) {
   // or even if the user selects something from a dropdown list. (That later
   // case could probably be detected in order to avoid doing matching here.)
   //
-  // I expect the actual matching to be pretty fast (assuming that there
-  // aren't thousands of active samples); the main bottleneck is how requests
-  // are made to the server from modifyWell() and patchWell() instead of in
-  // batch operations.
+  // This functionality has not been stress-tested on large-scale datasets
+  // (e.g. the American Gut Project) yet; this is a major TODO, as part of
+  // issue #173 on GitHub.
+  //
+  // A major bottleneck here, I think, will be how requests are made on a well-
+  // by-well basis to the server in patchWell() instead of in batch operations.
   var possiblyMatchedContent = content;
   // TODO: cache list of active samples so that we don't have to make this
   // particular request every time modifyWell() is called. See #592 in GH repo.

--- a/labcontrol/gui/static/js/plateViewer.js
+++ b/labcontrol/gui/static/js/plateViewer.js
@@ -745,7 +745,7 @@ function autocomplete_search_samples(request, response) {
   // Perform all the requests to the server
   var requests = [$.get("/sample/control?term=" + request.term)];
   $.each(studyIds, function(index, value) {
-    requests.push($.get("/study/" + value + "/samples?term=" + request.term));
+    requests.push($.get("/study/" + value + "/samples?limit=20&term=" + request.term));
   });
 
   $.when.apply($, requests).then(function() {

--- a/labcontrol/gui/static/js/plateViewer.js
+++ b/labcontrol/gui/static/js/plateViewer.js
@@ -440,8 +440,7 @@ PlateViewer.prototype.getActiveStudy = function() {
  * @param {int} row The row of the well being modified
  * @param {int} col The column of the well being modified
  * @param {string} content The new content of the well
- * @param {string} studyID The output of getActiveStudy() -- this paradigm
- *      should really be changed in the future to accommodate multiple studies.
+ * @param {string} studyID The output of getActiveStudy()
  *
  */
 PlateViewer.prototype.patchWell = function(row, col, content, studyID) {

--- a/labcontrol/gui/static/js/plateViewer.js
+++ b/labcontrol/gui/static/js/plateViewer.js
@@ -500,7 +500,7 @@ PlateViewer.prototype.modifyWell = function(row, col, content) {
   // aren't thousands of active samples); the main bottleneck is how requests
   // are made to the server from modifyWell() and patchWell() instead of in
   // batch operations.
-  var possiblyNewContent = content;
+  var possiblyMatchedContent = content;
   // TODO: cache list of active samples so that we don't have to make this
   // particular request every time modifyWell() is called.
   get_active_samples().then(
@@ -511,14 +511,14 @@ PlateViewer.prototype.modifyWell = function(row, col, content) {
       // cell content.
       var matchingSamples = getSubstringMatches(content, sampleIDs);
       if (matchingSamples.length === 1) {
-        possiblyNewContent = matchingSamples[0];
+        possiblyMatchedContent = matchingSamples[0];
         safeArrayDelete(that.wellClasses[row][col], "well-indeterminate");
       } else if (matchingSamples.length > 1) {
         addIfNotPresent(that.wellClasses[row][col], "well-indeterminate");
       } else {
         safeArrayDelete(that.wellClasses[row][col], "well-indeterminate");
       }
-      that.patchWell(row, col, possiblyNewContent, studyID);
+      that.patchWell(row, col, possiblyMatchedContent, studyID);
     },
     function(rejectionReason) {
       bootstrapAlert(

--- a/labcontrol/gui/static/js/plateViewer.js
+++ b/labcontrol/gui/static/js/plateViewer.js
@@ -286,10 +286,8 @@ PlateViewer.prototype.initialize = function(rows, cols) {
     // functions like this one.
     if (this.checked) {
       that.grid.registerPlugin(that.cellExternalCopyManager);
-      // console.log("cecm plugin registered");
     } else {
       that.grid.unregisterPlugin(that.cellExternalCopyManager);
-      // console.log("cecm plugin UNregistered");
     }
   });
   // This paradigm inspired by
@@ -518,13 +516,10 @@ PlateViewer.prototype.modifyWell = function(row, col, content) {
     var matchingSamples = getSubstringMatches(content, sampleIDs);
     if (matchingSamples.length === 1) {
       possiblyNewContent = matchingSamples[0];
-      console.log("Resolved", content, "to", possiblyNewContent);
       safeArrayDelete(that.wellClasses[row][col], "well-indeterminate");
     } else if (matchingSamples.length > 1) {
-      console.log("Multi-match on ", content);
       addIfNotPresent(that.wellClasses[row][col], "well-indeterminate");
     } else {
-      console.log("Couldn't resolve", content);
       safeArrayDelete(that.wellClasses[row][col], "well-indeterminate");
     }
     that.patchWell(row, col, possiblyNewContent, studyID);

--- a/labcontrol/gui/static/js/plateViewer.js
+++ b/labcontrol/gui/static/js/plateViewer.js
@@ -502,7 +502,7 @@ PlateViewer.prototype.modifyWell = function(row, col, content) {
   // batch operations.
   var possiblyMatchedContent = content;
   // TODO: cache list of active samples so that we don't have to make this
-  // particular request every time modifyWell() is called.
+  // particular request every time modifyWell() is called. See #592 in GH repo.
   get_active_samples().then(
     function(sampleIDs) {
       // If there is *exactly one* match with an active sample ID, use

--- a/labcontrol/gui/static/js/plateViewer.js
+++ b/labcontrol/gui/static/js/plateViewer.js
@@ -436,39 +436,6 @@ PlateViewer.prototype.getActiveStudy = function() {
 
 /**
  *
- * Given a query string and an array of strings to search through, returns a
- * subset of the array containing only strings that contain the query string.
- *
- * This search is case insensitive, so "abc" will match with "ABCDEF".
- *
- * Note that if queryString is empty (i.e. "") then this won't return any
- * matches, even if "" is present in stringArray for some reason (since
- * stringArray should be a list of sample IDs, this should never be the case).
- *
- * This function is loosely based on textFilterFeatures() in Qurro:
- * https://github.com/biocore/qurro/blob/3f4650fb677753e978d971b06794d4790b051d30/qurro/support_files/js/feature_computation.js#L29
- *
- * @param {string} queryString The string that will be searched for
- * @param {array} stringArray Collection of strings to check against the query
- * @returns {array} Collection of strings in stringArray that include the query
- *
- */
-function getSubstringMatches(queryString, stringArray) {
-  if (queryString.length === 0 || stringArray.length === []) {
-    return [];
-  }
-  var queryStringLowerCase = queryString.toLowerCase();
-  var matchingStrings = [];
-  for (var i = 0; i < stringArray.length; i++) {
-    if (stringArray[i].toLowerCase().includes(queryStringLowerCase)) {
-      matchingStrings.push(stringArray[i]);
-    }
-  }
-  return matchingStrings;
-}
-
-/**
- *
  * Actually updates a well's content in the backend. This code was ripped out
  * of PlateViewer.modifyWell().
  *

--- a/labcontrol/gui/static/js/plateViewer.js
+++ b/labcontrol/gui/static/js/plateViewer.js
@@ -454,17 +454,17 @@ PlateViewer.prototype.getActiveStudy = function() {
  *
  */
 function getSubstringMatches(queryString, stringArray) {
-    if (queryString.length === 0 || stringArray.length === []) {
-        return [];
+  if (queryString.length === 0 || stringArray.length === []) {
+    return [];
+  }
+  var queryStringLowerCase = queryString.toLowerCase();
+  var matchingStrings = [];
+  for (var i = 0; i < stringArray.length; i++) {
+    if (stringArray[i].toLowerCase().includes(queryStringLowerCase)) {
+      matchingStrings.push(stringArray[i]);
     }
-    var queryStringLowerCase = queryString.toLowerCase();
-    var matchingStrings = [];
-    for (var i = 0; i < stringArray.length; i++) {
-        if (stringArray[i].toLowerCase().includes(queryStringLowerCase)) {
-            matchingStrings.push(stringArray[i]);
-        }
-    }
-    return matchingStrings;
+  }
+  return matchingStrings;
 }
 
 /**
@@ -526,34 +526,25 @@ PlateViewer.prototype.modifyWell = function(row, col, content) {
   var that = this,
     studyID = this.getActiveStudy();
 
-  if ($("#multiSelectCheckbox").prop("checked")) {
-    // Perform automatic matching
-    var possiblyNewContent = content;
-    get_active_samples().then(
-        function(sampleIDs) {
-            // If there is *exactly one* match with an active sample ID, use
-            // that instead. In any other case (0 matches or > 1 matches),
-            // manual resolution is required -- so we don't bother changing the
-            // cell content.
-            var matchingSamples = getSubstringMatches(content, sampleIDs);
-            if (matchingSamples.length === 1) {
-                possiblyNewContent = matchingSamples[0];
-                console.log("Resolved", content, "to", possiblyNewContent);
-            }
-            else if (matchingSamples.length > 1) {
-                // TODO: apply the well-indeterminate class for this well
-                console.log("Multi-match on ", content);
-            }
-            else {
-                console.log("Couldn't resolve", content);
-            }
-            that.patchWell(row, col, possiblyNewContent);
-        }
-    );
-  } else {
-    console.log("multiselect checkbox not checked");
-    this.patchWell(row, col, content);
-  }
+  // Perform automatic matching
+  var possiblyNewContent = content;
+  get_active_samples().then(function(sampleIDs) {
+    // If there is *exactly one* match with an active sample ID, use
+    // that instead. In any other case (0 matches or > 1 matches),
+    // manual resolution is required -- so we don't bother changing the
+    // cell content.
+    var matchingSamples = getSubstringMatches(content, sampleIDs);
+    if (matchingSamples.length === 1) {
+      possiblyNewContent = matchingSamples[0];
+      console.log("Resolved", content, "to", possiblyNewContent);
+    } else if (matchingSamples.length > 1) {
+      console.log("Multi-match on ", content);
+      // that.wellClasses[row][col].push("well-indeterminate");
+    } else {
+      console.log("Couldn't resolve", content);
+    }
+    that.patchWell(row, col, possiblyNewContent);
+  });
 };
 
 /**

--- a/labcontrol/gui/static/js/plateViewer.js
+++ b/labcontrol/gui/static/js/plateViewer.js
@@ -548,11 +548,13 @@ PlateViewer.prototype.modifyWell = function(row, col, content) {
     if (matchingSamples.length === 1) {
       possiblyNewContent = matchingSamples[0];
       console.log("Resolved", content, "to", possiblyNewContent);
+      safeArrayDelete(that.wellClasses[row][col], "well-indeterminate");
     } else if (matchingSamples.length > 1) {
       console.log("Multi-match on ", content);
-      // that.wellClasses[row][col].push("well-indeterminate");
+      addIfNotPresent(that.wellClasses[row][col], "well-indeterminate");
     } else {
       console.log("Couldn't resolve", content);
+      safeArrayDelete(that.wellClasses[row][col], "well-indeterminate");
     }
     that.patchWell(row, col, possiblyNewContent, studyID);
   });

--- a/labcontrol/gui/static/js/plateViewer.js
+++ b/labcontrol/gui/static/js/plateViewer.js
@@ -527,7 +527,7 @@ PlateViewer.prototype.modifyWell = function(row, col, content) {
     },
     function(rejectionReason) {
       bootstrapAlert(
-        "Attempting to get a list of sample IDs failed:" + rejectionReason,
+        "Attempting to get a list of sample IDs failed: " + rejectionReason,
         "danger"
       );
     }
@@ -820,11 +820,15 @@ function autocomplete_search_samples(request, response) {
       });
       response(results);
     },
-    function(rejectionReason) {
+    // If any of the requests fail, the arguments to this "rejection"
+    // function match the arguments to the corresponding request's
+    // "error" function: see https://api.jquery.com/jquery.when/, towards the
+    // bottom of the page. (So we can just show the user jqXHR.responseText.)
+    function(jqXHR, textStatus, errorThrown) {
       bootstrapAlert(
         "Attempting to get sample IDs while filling up the autocomplete " +
           "dropdown menu failed: " +
-          rejectionReason,
+          jqXHR.responseText,
         "danger"
       );
     }
@@ -911,9 +915,10 @@ function get_active_samples() {
         var arg = requests.length === 1 ? [arguments] : arguments;
         return merge_sample_responses(arg);
       },
-      function(rejectionReason) {
+      function(jqXHR, textStatus, errorThrown) {
         bootstrapAlert(
-          "Attempting to get a list of sample IDs failed:" + rejectionReason,
+          "Attempting to get a list of sample IDs failed: " +
+            jqXHR.responseText,
           "danger"
         );
       }

--- a/labcontrol/gui/static/js/plateViewer.js
+++ b/labcontrol/gui/static/js/plateViewer.js
@@ -527,8 +527,18 @@ PlateViewer.prototype.modifyWell = function(row, col, content) {
   var that = this,
     studyID = this.getActiveStudy();
 
-  // Perform automatic matching
+  // Perform automatic matching. Note that this is currently done every time
+  // modifyWell() is called, even if the user types in something like "blank"
+  // or even if the user selects something from a dropdown list. (That later
+  // case could probably be detected in order to avoid doing matching here.)
+  //
+  // I expect the actual matching to be pretty fast (assuming that there
+  // aren't thousands of active samples); the main bottleneck is how requests
+  // are made to the server from modifyWell() and patchWell() instead of in
+  // batch operations.
   var possiblyNewContent = content;
+  // TODO: cache list of active samples so that we don't have to make this
+  // particular request every time modifyWell() is called.
   get_active_samples().then(function(sampleIDs) {
     // If there is *exactly one* match with an active sample ID, use
     // that instead. In any other case (0 matches or > 1 matches),

--- a/labcontrol/gui/static/js/plateViewer.js
+++ b/labcontrol/gui/static/js/plateViewer.js
@@ -492,6 +492,10 @@ PlateViewer.prototype.patchWell = function(row, col, content, studyID) {
     },
     success: function(data) {
       that.data[row][that.grid.getColumns()[col].field] = data["sample_id"];
+      // NOTE: this pretty much checks the status of every well, and this is
+      // called in patchWell (i.e. every time a well is updated). Should be a
+      // lot more efficient to minimize the impact of this by just checking for
+      // changes relative to this well?
       that.updateUnknownsAndDuplicates();
       var classIdx = that.wellClasses[row][col].indexOf("well-prev-plated");
       if (data["previous_plates"].length > 0) {

--- a/labcontrol/gui/static/js/plateViewer.js
+++ b/labcontrol/gui/static/js/plateViewer.js
@@ -522,7 +522,9 @@ PlateViewer.prototype.modifyWell = function(row, col, content) {
     },
     function(rejectionReason) {
       bootstrapAlert(
-        "Attempting to get a list of sample IDs failed: " + rejectionReason,
+        "Attempting to get a list of sample IDs in PlateViewer.modifyWell() " +
+          "failed: " +
+          rejectionReason,
         "danger"
       );
     }
@@ -822,7 +824,7 @@ function autocomplete_search_samples(request, response) {
     function(jqXHR, textStatus, errorThrown) {
       bootstrapAlert(
         "Attempting to get sample IDs while filling up the autocomplete " +
-          "dropdown menu failed: " +
+          "dropdown menu in autocomplete_search_samples() failed: " +
           jqXHR.responseText,
         "danger"
       );
@@ -839,11 +841,11 @@ function autocomplete_search_samples(request, response) {
  * autocomplete_search_samples() (where this code was taken from) and
  * get_active_samples().
  *
- * NOTE that this assumes that the sample IDs in the response array are all
- * unique. If for whatever reason a sample ID is repeated in a study -- or
- * multiple studies share a sample ID -- then this function won't have a
- * problem with that, and will accordingly return an array containing duplicate
- * sample IDs. (That should never happen, though.)
+ * NOTE that this does not account for cases where there are duplicate
+ * sample IDs in the input. If for whatever reason a sample ID is repeated in a
+ * study -- or multiple studies share a sample ID -- then this function won't
+ * have a problem with that, and will accordingly return an array containing
+ * duplicate sample IDs. (That should never happen, though.)
  *
  * @param {Array} responseArray: an array of request(s') output.
  * @returns {Array} A list of the sample IDs contained within responseArray.
@@ -912,7 +914,8 @@ function get_active_samples() {
       },
       function(jqXHR, textStatus, errorThrown) {
         bootstrapAlert(
-          "Attempting to get a list of sample IDs failed: " +
+          "Attempting to get a list of sample IDs in get_active_samples() " +
+            "failed: " +
             jqXHR.responseText,
           "danger"
         );

--- a/labcontrol/gui/static/js/plateViewer.js
+++ b/labcontrol/gui/static/js/plateViewer.js
@@ -434,7 +434,7 @@ PlateViewer.prototype.getActiveStudy = function() {
 
 /**
  *
- * Actually updates a well's content in the backend. This code was ripped out
+ * Actually update a well's content in the backend. This code was ripped out
  * of PlateViewer.modifyWell().
  *
  * @param {int} row The row of the well being modified

--- a/labcontrol/gui/templates/plate.html
+++ b/labcontrol/gui/templates/plate.html
@@ -213,9 +213,9 @@
           </section>
           <!-- Hidden section added to populate a full row; otherwise, Well
               comments will not be left-justified. -->
-          <section id='plate-map-legend-indeterminate' class='legend-entry' style="visibility: hidden">
-            <div id='plate-map-legend-indeterminate-box' class='well-indeterminate legend-patch'></div>
-            <div id='plate-map-legend-indeterminate-text' class='legend-text'>
+          <section class='legend-entry' style="visibility: hidden">
+            <div class='well-indeterminate legend-patch'></div>
+            <div class='legend-text'>
              <p> Specimen ID matches more than one member of the attached
              studies; if left unresolved, will show up as "not a member of the
              attached studies" when reloading this plate</p>

--- a/labcontrol/gui/templates/plate.html
+++ b/labcontrol/gui/templates/plate.html
@@ -206,7 +206,9 @@
           <section id='plate-map-legend-indeterminate' class='legend-entry'>
             <div id='plate-map-legend-indeterminate-box' class='well-indeterminate legend-patch'></div>
             <div id='plate-map-legend-indeterminate-text' class='legend-text'>
-             <p> Specimen ID matches more than one member of the attached studies</p>
+             <p> Specimen ID matches more than one member of the attached
+             studies; if left unresolved, will show up as "not a member of the
+             attached studies" when reloading this plate</p>
             </div>
           </section>
           <!-- Hidden section added to populate a full row; otherwise, Well
@@ -214,7 +216,9 @@
           <section id='plate-map-legend-indeterminate' class='legend-entry' style="visibility: hidden">
             <div id='plate-map-legend-indeterminate-box' class='well-indeterminate legend-patch'></div>
             <div id='plate-map-legend-indeterminate-text' class='legend-text'>
-             <p> Specimen ID matches more than one member of the attached studies</p>
+             <p> Specimen ID matches more than one member of the attached
+             studies; if left unresolved, will show up as "not a member of the
+             attached studies" when reloading this plate</p>
             </div>
           </section>
         </div>

--- a/labcontrol/gui/test/test_study.py
+++ b/labcontrol/gui/test/test_study.py
@@ -121,6 +121,7 @@ class TestStudyHandlers(TestHandlerBase):
 
         # test non-existent study
         response = self.get('/study/400/sample_search')
+        self.assertEqual(response.code, 404)
 
     def test_get_study_summary_handler(self):
         response = self.get('/study/1/summary')

--- a/labcontrol/gui/test/test_study.py
+++ b/labcontrol/gui/test/test_study.py
@@ -74,6 +74,22 @@ class TestStudyHandlers(TestHandlerBase):
         obs = json_decode(response.body)
         self.assertEqual(obs, all_s1_samples)
 
+        # Try some invalid limits
+        response = self.get('/study/1/samples?limit=0')
+        self.assertEqual(response.code, 400)
+        response = self.get('/study/1/samples?limit=0.1')
+        self.assertEqual(response.code, 400)
+        response = self.get('/study/1/samples?limit=1.0')
+        self.assertEqual(response.code, 400)
+        response = self.get('/study/1/samples?limit=-1')
+        self.assertEqual(response.code, 400)
+        response = self.get('/study/1/samples?limit=27.0')
+        self.assertEqual(response.code, 400)
+        response = self.get('/study/1/samples?limit=000')
+        self.assertEqual(response.code, 400)
+        response = self.get('/study/1/samples?limit=abcdefg')
+        self.assertEqual(response.code, 400)
+
         # Using a "term" filters samples to just those that contain that term
         response = self.get('/study/1/samples?term=SKB')
         self.assertEqual(response.code, 200)

--- a/labcontrol/gui/test/test_study.py
+++ b/labcontrol/gui/test/test_study.py
@@ -83,6 +83,8 @@ class TestStudyHandlers(TestHandlerBase):
         self.assertEqual(response.code, 400)
         response = self.get('/study/1/samples?limit=-1')
         self.assertEqual(response.code, 400)
+        response = self.get('/study/1/samples?limit=-1.0')
+        self.assertEqual(response.code, 400)
         response = self.get('/study/1/samples?limit=27.0')
         self.assertEqual(response.code, 400)
         response = self.get('/study/1/samples?limit=000')

--- a/labcontrol/gui/test/test_study.py
+++ b/labcontrol/gui/test/test_study.py
@@ -89,6 +89,10 @@ class TestStudyHandlers(TestHandlerBase):
         self.assertEqual(response.code, 400)
         response = self.get('/study/1/samples?limit=abcdefg')
         self.assertEqual(response.code, 400)
+        response = self.get('/study/1/samples?limit=None')
+        self.assertEqual(response.code, 400)
+        response = self.get('/study/1/samples?limit=abcdefg&term=skm')
+        self.assertEqual(response.code, 400)
 
         # Using a "term" filters samples to just those that contain that term
         response = self.get('/study/1/samples?term=SKB')
@@ -129,10 +133,12 @@ class TestStudyHandlers(TestHandlerBase):
         exp = ['1.SKM1.640183', '1.SKM2.640199']
         self.assertEqual(obs, exp)
 
-        response = self.get('/study/1/samples?term=SKM&limit=3')
+        response = self.get('/study/1/samples?term=SKM&limit=30')
         self.assertEqual(response.code, 200)
         obs = json_decode(response.body)
-        exp = ['1.SKM1.640183', '1.SKM2.640199']
+        exp = ['1.SKM1.640183', '1.SKM2.640199', '1.SKM3.640197',
+               '1.SKM4.640180', '1.SKM5.640177', '1.SKM6.640187',
+               '1.SKM7.640188', '1.SKM8.640201', '1.SKM9.640192']
         self.assertEqual(obs, exp)
 
         # test non-existent study

--- a/labcontrol/gui/test/test_study.py
+++ b/labcontrol/gui/test/test_study.py
@@ -41,15 +41,40 @@ class TestStudyHandlers(TestHandlerBase):
         response = self.get('/study/1/samples')
         self.assertEqual(response.code, 200)
         obs = json_decode(response.body)
-        exp = ['1.SKB1.640202', '1.SKB2.640194', '1.SKB3.640195',
-               '1.SKB4.640189', '1.SKB5.640181', '1.SKB6.640176',
-               '1.SKB7.640196', '1.SKB8.640193', '1.SKB9.640200',
-               '1.SKD1.640179', '1.SKD2.640178', '1.SKD3.640198',
-               '1.SKD4.640185', '1.SKD5.640186', '1.SKD6.640190',
-               '1.SKD7.640191', '1.SKD8.640184', '1.SKD9.640182',
-               '1.SKM1.640183', '1.SKM2.640199']
-        self.assertEqual(obs, exp)
+        all_s1_samples = ['1.SKB1.640202', '1.SKB2.640194', '1.SKB3.640195',
+                          '1.SKB4.640189', '1.SKB5.640181', '1.SKB6.640176',
+                          '1.SKB7.640196', '1.SKB8.640193', '1.SKB9.640200',
+                          '1.SKD1.640179', '1.SKD2.640178', '1.SKD3.640198',
+                          '1.SKD4.640185', '1.SKD5.640186', '1.SKD6.640190',
+                          '1.SKD7.640191', '1.SKD8.640184', '1.SKD9.640182',
+                          '1.SKM1.640183', '1.SKM2.640199', '1.SKM3.640197',
+                          '1.SKM4.640180', '1.SKM5.640177', '1.SKM6.640187',
+                          '1.SKM7.640188', '1.SKM8.640201', '1.SKM9.640192']
+        self.assertEqual(obs, all_s1_samples)
 
+        # Using a "limit" imposes a cutoff on the number of samples returned,
+        # if needed. 20 is the limit used in autocomplete_search_samples() in
+        # the front-end code.
+        response = self.get('/study/1/samples?limit=20')
+        self.assertEqual(response.code, 200)
+        obs = json_decode(response.body)
+        lim20_s1_samples = ['1.SKB1.640202', '1.SKB2.640194', '1.SKB3.640195',
+                            '1.SKB4.640189', '1.SKB5.640181', '1.SKB6.640176',
+                            '1.SKB7.640196', '1.SKB8.640193', '1.SKB9.640200',
+                            '1.SKD1.640179', '1.SKD2.640178', '1.SKD3.640198',
+                            '1.SKD4.640185', '1.SKD5.640186', '1.SKD6.640190',
+                            '1.SKD7.640191', '1.SKD8.640184', '1.SKD9.640182',
+                            '1.SKM1.640183', '1.SKM2.640199']
+        self.assertEqual(obs, lim20_s1_samples)
+
+        # Using a limit of greater than the number of samples in this study (in
+        # this case, 27) doesn't alter the output
+        response = self.get('/study/1/samples?limit=50')
+        self.assertEqual(response.code, 200)
+        obs = json_decode(response.body)
+        self.assertEqual(obs, all_s1_samples)
+
+        # Using a "term" filters samples to just those that contain that term
         response = self.get('/study/1/samples?term=SKB')
         self.assertEqual(response.code, 200)
         obs = json_decode(response.body)
@@ -68,6 +93,30 @@ class TestStudyHandlers(TestHandlerBase):
         self.assertEqual(response.code, 200)
         obs = json_decode(response.body)
         exp = ['1.SKB1.640202', '1.SKD1.640179', '1.SKM1.640183']
+        self.assertEqual(obs, exp)
+
+        # "limit" and "term" should be usable together
+        response = self.get('/study/1/samples?term=S&limit=20')
+        self.assertEqual(response.code, 200)
+        obs = json_decode(response.body)
+        self.assertEqual(obs, lim20_s1_samples)
+
+        response = self.get('/study/1/samples?term=SKM&limit=1')
+        self.assertEqual(response.code, 200)
+        obs = json_decode(response.body)
+        exp = ['1.SKM1.640183']
+        self.assertEqual(obs, exp)
+
+        response = self.get('/study/1/samples?term=SKM&limit=2')
+        self.assertEqual(response.code, 200)
+        obs = json_decode(response.body)
+        exp = ['1.SKM1.640183', '1.SKM2.640199']
+        self.assertEqual(obs, exp)
+
+        response = self.get('/study/1/samples?term=SKM&limit=3')
+        self.assertEqual(response.code, 200)
+        obs = json_decode(response.body)
+        exp = ['1.SKM1.640183', '1.SKM2.640199']
         self.assertEqual(obs, exp)
 
         # test non-existent study


### PR DESCRIPTION
Progress on #520 / #553. (Both of those issues have a couple moving parts, but this should address what I think is the "main" thing with both.)

## Summary of changes
- Added `getSubstringMatches()`, a simple function that (given a query string and an array of strings) returns all strings in the array that include the query string
  - Added corresponding unit tests
- Added `get_active_samples()` (named analogously to the existing `get_active_studies()`). This function just gets all sample IDs associated with all active studies. (It technically returns a `Promise` that resolves to an array of sample IDs, since the requests are done asynchronously.)
  - Made some modifications in the back-end code to enable this -- in particular, exposing a `limit` parameter that allows the front-end to issue a request for *all* samples associated with a study instead of just 20.
  - Added various tests to verify that `limit`s are being handled properly. 
  - Thanks to @charles-cowart for help with this!
  - Also created `merge_sample_responses()`, which is just a few lines of code I abstracted out from `autocomplete_search_samples()` so that I could use it in both that function and in `get_active_samples()`.
- Added an "error" function in `autocomplete_search_samples()` (which didn't previously have one). This function just creates a `bootstrapAlert()` explaining the situation.
  - Also added two other error functions to the two other instances in `plateViewer.js` that use `.then()` (i.e. Promises).
  - See the commit message of https://github.com/biocore/LabControl/pull/585/commits/ed55343e6c9855d92db0c9f0383fbefdbbcdfd86 for more details about this than are probably necessary.

- `PlateViewer.modifyWell()` now uses `get_active_samples()` and `getSubstringMatches()` to perform client-side matching: given an input specimen ID, this tries to match it up with an active sample ID.
  - There are three possible results of this:
    - exactly 1 sample matches --> great, change the well contents accordingly
    - 0 samples match --> ok, this well will just be labelled "unknown"
    - 2 or more samples match --> assign the new class "indeterminate" (it's the yellow one) to this well, indicating that manual resolution is needed. **On reloading a plate, these wells will show up as red (i.e. "unknown")** -- see caveats below. 
  - The main AJAX call that `PlateViewer.modifyWell()` used to do is now done in `PlateViewer.patchWell()`. I initially did this so I could call `patchWell()` from multiple points, but this ended up not being needed. (I still like having `modifyWell()` and `patchWell()` be separate functions, though. Feel free to ask for them to be renamed :)
  - Changed the "intermediate" well legend to reflect the behavior on reloading.
- Various small fixes around the codebase (adding missing docs in process.py, removed an unused variable declaration in plate.js, added Travis/Coveralls badges to the README, etc.)

## Caveats
There are some things I still think could be improved in the proposed changes -- noting them here because most of these are sorta subjective, so if you have any feedback I'd appreciate it.
- Client-side matching is fairly quick (at least on my computer), but it could be faster if we did stuff like caching the list of active sample IDs. The golden standard here would be applying all of these changes in bulk (instead of doing everything through `modifyWell()`, which is why you see samples' statuses change in individual "blips")... but this would probably necessitate some significant restructuring of how the plating interface works.

- ~~Some of the uses of promises in the code could be handled better (e.g. throwing a bootstrapAlert if a promise fails to resolve).~~ **Update: resolved as of https://github.com/biocore/LabControl/pull/585/commits/ed55343e6c9855d92db0c9f0383fbefdbbcdfd86.**

- This is the main caveat: after spending some time going through the code that handles well classes, it seems like adding an indeterminate class to wells on the front-end is pretty simple (as is done here). However, making that class persist on the back-end (so that reloading a plate reloads the class for each well) is going to be a pretty heavy amount of work on top of what's been done here: it seems like we'd need to modify the database schema to store this information, or at least figure out a way to use a SQL query to detect *in python* which wells are indeterminate. Took a few stabs at this last night; didn't get very far.
  - To complicate things, indeterminate wells are technically "unknown", since they don't have a valid value. From what I can tell, making these wells not "unknown" seems like it'd involve a lot of going through the code to modify things.
  - For now, the behavior is that (as mentioned above) the indeterminate class isn't preserved when reloading a plate—indeterminate cells will just show up on a reload as "unknown", which is *technically* kinda accurate since they don't contain exact sample IDs. Although technically accurate, this is fairly undesirable. (As mentioned, I updated the indeterminate legend to match, so that users understand why these cells change on reloading.)
  - I'm sure making the indeterminate class persistent is doable—and I'm happy to work when I get back next week on this—but I'm not sure that the effort is worth it, especially since the yellow cells are an indicator of "hey you need to resolve this manually". Of course if you disagree that is fine, I'm not the expert here :)

Anyway—sorry if this PR isn't comprehensive enough; I mainly wanted to make sure I had this ready to show you all where this is at today. Let me know what you think!

<img width="1552" alt="Screen Shot 2019-08-30 at 8 34 02 AM" src="https://user-images.githubusercontent.com/4177727/64020999-fc9b8580-cb00-11e9-9e52-da2ae8771784.png">